### PR TITLE
docs: bring the reference docs back in line with the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,38 +245,18 @@ More modes, more engines, more platforms — and it's free. If you've been payin
 
 ## Platform support
 
-| Capability                | macOS | Linux | Windows |
-| :------------------------ | :---: | :---: | :-----: |
-| Recursive Grid            |  ✅   |  ✅   |   ✅    |
-| Grid                      |  ✅   |  ✅   |   ✅    |
-| Vim-Style Scroll          |  ✅   |  ✅   |   ✅    |
-| Hints (Accessibility API) |  ✅   |  🔵   |   🔵    |
-| Hints (Vision OCR)        |  ✅   |  🔵   |   🔲    |
-| Direct Mouse Injection    |  ✅   |  ✅   |   ✅    |
-| Global Hotkeys            |  ✅   |  ✅   |   ✅    |
-| Native Overlays           |  ✅   |  ✅   |   ✅    |
-| Monitor Select            |  ✅   |  ✅   |   🔲    |
+Every mode runs on macOS, Linux (X11 and Wayland) and Windows. The difference
+is hints: on macOS they read the full accessibility tree, while on Linux
+(AT-SPI) and Windows (UI Automation) coverage depends on what each app exposes,
+with a text-only OCR fallback where the tree is too thin. The capability
+matrix in the cross-platform guide is the single source of truth for what works
+where, with the mechanism behind each cell.
 
-✅ full · 🔵 works with limits · 🔲 not available
-
-**Hints caveats.** On **Linux**, hints work through AT-SPI, so coverage depends
-on the app exposing an accessibility tree (GTK/Qt do; Chromium and Electron apps
-need `--force-renderer-accessibility`). Where that tree is too thin, Vision OCR
-is the fallback — tesseract, text only, and on KDE behind a one-time
-screen-sharing prompt, because KWin's only pixel source is the desktop portal.
-On **Windows**, UI Automation reports the control view only,
-per-app config does not re-apply when you change windows,
-and the OCR fallback is `Windows.Media.Ocr`, text only, needing a language pack. **Linux runs on X11 or Wayland on
-wlroots/KWin/COSMIC/GNOME**; on GNOME Wayland the overlay is drawn through
-Xwayland and the focused window comes from a shell extension Neru installs.
-
-→ [Roadmap](docs/ROADMAP.md) · [Cross-platform details](docs/CROSS_PLATFORM.md)
+→ [Cross-platform details](docs/CROSS_PLATFORM.md#capability-matrix) · [Roadmap](docs/ROADMAP.md)
 
 ---
 
 ## Documentation
-
-Everything you need to go deep:
 
 **Using Neru**
 
@@ -316,8 +296,7 @@ are **executable**: the guardrail tests in
 [`internal/architecture/`](internal/architecture/) pin the layering, platform
 isolation, port/mock parity, and even doc-link integrity — each with a comment
 explaining the real bug it prevents. If you break a rule, the failure message
-tells you how to fix it. Adding a feature or platform adapter is straightforward,
-and pull requests are very welcome.
+tells you how to fix it. Pull requests are welcome.
 
 ```bash
 git checkout -b feature/your-feature

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,8 +255,7 @@ adapter/platform/{gnomeshell,kwin,compositorcli}     per-compositor helpers the 
 Smaller capabilities (`appwatcher`, `keyfeed`, `vision`) stay one package
 each, with one build-tagged file per OS beside a shared shell
 (`platform_darwin.go`, `platform_linux.go`, `platform_windows.go`, and an
-`_other.go` fallback). `textinput` is the one whose darwin bridge is the only
-real implementation, so it carries just the darwin file and the fallback.
+`_other.go` fallback); `textinput` carries a darwin file and the fallback.
 
 The parent package holds the port adapter and a small build-tagged factory —
 the only place that knows which implementation exists. So "what do I touch to
@@ -493,12 +492,12 @@ its own.
 
 ## Security Architecture
 
-1. **Secure input detection** — before activating any mode Neru asks the
-   system port whether secure input is engaged (e.g. a focused password
-   field); if so it refuses with `CodeSecureInputEnabled` and notifies the
-   user, so no mode ever captures keys into a password field. Which platforms
-   can answer that question is in the
-   [capability matrix](CROSS_PLATFORM.md#capability-matrix).
+1. **Secure input detection** — before activating hints, grid, recursive
+   grid or monitor select, the handler asks the system port whether secure
+   input is engaged (e.g. a focused password field); if so it refuses with
+   `CodeSecureInputEnabled` and notifies the user. Scroll and user-declared
+   modes do not run that check. Which platforms can answer the question is in
+   the [capability matrix](CROSS_PLATFORM.md#capability-matrix).
 2. **Permissions** — Accessibility permission is required on macOS; Neru requests
    only the minimum needed for UI interaction.
 3. **IPC security** — the endpoint is scoped to one user, and the daemon checks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,9 @@ events. When activated it offers several navigation modes:
 - **Grid** — divides the screen into a coordinate-based grid
 - **Recursive grid** — recursive cell navigation with center preview and backtracking
 - **Scroll** — Vim-style scrolling at the cursor position
+- **Monitor select** — labels each display so the cursor can jump between them
+- **Custom modes** — user-declared modes in `[modes.<name>]`, entered with
+  `neru mode <name>`
 
 The architecture targets low latency and cross-platform extensibility while
 integrating deeply with native APIs. macOS is the reference implementation;
@@ -246,7 +249,12 @@ adapter/systray/{darwin,linux,windows}               tray icon
 adapter/accessibility/{ax,atspi,native}              element discovery
 adapter/overlay/{manager,darwin,linux,windows}       overlay rendering
 adapter/platform/{darwin,linux,windows}              the native cgo bridges
+adapter/platform/{gnomeshell,kwin,compositorcli}     per-compositor helpers the linux bridge routes to
 ```
+
+Smaller capabilities (`appwatcher`, `textinput`, `keyfeed`, `vision`) stay one
+package each, with a build-tagged `platform_darwin.go` / `platform_other.go`
+pair where the darwin bridge is the only real implementation.
 
 The parent package holds the port adapter and a small build-tagged factory —
 the only place that knows which implementation exists. So "what do I touch to
@@ -305,16 +313,20 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant M as Mode (App)
-    participant S as Service (App)
     participant OA as Overlay Adapter (Infra)
     participant B as Bridge (CGo)
     participant C as Cocoa (macOS)
 
-    M->>S: Request Display
-    S->>OA: ShowOverlay(elements)
+    M->>OA: ShowFrame(frame)
+    OA->>OA: resolve Style, build render models
     OA->>B: DrawLabels(rects)
     B->>C: Render Native Windows
 ```
+
+A mode hands the overlay adapter a `ports.Frame` of domain values and nothing
+else; resolving styles and running the show/switch/draw sequence is the
+adapter's job (`internal/adapter/overlay/AGENTS.md`). Services never touch the
+overlay.
 
 On macOS each component owns its own NSPanel and calls the Objective-C bridge
 directly. On Linux and Windows the overlay **manager** does all drawing into one
@@ -426,15 +438,15 @@ before anything else, required by Cocoa. Non-macOS builds omit it. Never add
 The codebase says "bundle ID" generically for the platform application
 identifier:
 
-| Platform | Term                        | Example                          |
-| -------- | --------------------------- | -------------------------------- |
-| macOS    | Bundle ID                   | `com.apple.Safari`               |
-| Linux    | Desktop ID / executable     | `firefox.desktop` or `firefox`   |
-| Windows  | AppUserModelID / executable | `Microsoft.Edge` or `msedge.exe` |
+| Platform | Term                              | Example                                   |
+| -------- | --------------------------------- | ----------------------------------------- |
+| macOS    | Bundle ID                         | `com.apple.Safari`                        |
+| Linux    | `WM_CLASS` (X11) / `app_id` (Wayland) | `firefox`                             |
+| Windows  | Process image path                | `C:\Program Files\...\msedge.exe`        |
 
 `ports.AccessibilityPort.FocusedAppBundleID` returns whatever the platform uses,
-and `general.excluded_apps` in the config should use the same format for the
-target platform.
+and `general.excluded_apps` matches it by exact string, so the config must use
+the same format for the target platform.
 
 ---
 
@@ -479,9 +491,10 @@ its own.
 
 ## Security Architecture
 
-1. **Secure input detection** — Neru detects when Secure Input is enabled (e.g.
-   a focused password field) and suspends the event tap, preventing unintended
-   key logging.
+1. **Secure input detection** — on macOS Neru checks for Secure Input (e.g. a
+   focused password field) before activating any mode, refuses with
+   `CodeSecureInputEnabled` and notifies the user, so no mode ever captures
+   keys into a password field. Other platforms report it as never enabled.
 2. **Permissions** — Accessibility permission is required on macOS; Neru requests
    only the minimum needed for UI interaction.
 3. **IPC security** — the endpoint is scoped to one user, and the daemon checks

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -252,9 +252,11 @@ adapter/platform/{darwin,linux,windows}              the native cgo bridges
 adapter/platform/{gnomeshell,kwin,compositorcli}     per-compositor helpers the linux bridge routes to
 ```
 
-Smaller capabilities (`appwatcher`, `textinput`, `keyfeed`, `vision`) stay one
-package each, with a build-tagged `platform_darwin.go` / `platform_other.go`
-pair where the darwin bridge is the only real implementation.
+Smaller capabilities (`appwatcher`, `keyfeed`, `vision`) stay one package
+each, with one build-tagged file per OS beside a shared shell
+(`platform_darwin.go`, `platform_linux.go`, `platform_windows.go`, and an
+`_other.go` fallback). `textinput` is the one whose darwin bridge is the only
+real implementation, so it carries just the darwin file and the fallback.
 
 The parent package holds the port adapter and a small build-tagged factory —
 the only place that knows which implementation exists. So "what do I touch to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -493,10 +493,12 @@ its own.
 
 ## Security Architecture
 
-1. **Secure input detection** — on macOS Neru checks for Secure Input (e.g. a
-   focused password field) before activating any mode, refuses with
-   `CodeSecureInputEnabled` and notifies the user, so no mode ever captures
-   keys into a password field. Other platforms report it as never enabled.
+1. **Secure input detection** — before activating any mode Neru asks the
+   system port whether secure input is engaged (e.g. a focused password
+   field); if so it refuses with `CodeSecureInputEnabled` and notifies the
+   user, so no mode ever captures keys into a password field. Which platforms
+   can answer that question is in the
+   [capability matrix](CROSS_PLATFORM.md#capability-matrix).
 2. **Permissions** — Accessibility permission is required on macOS; Neru requests
    only the minimum needed for UI interaction.
 3. **IPC security** — the endpoint is scoped to one user, and the daemon checks

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -986,8 +986,8 @@ neru action show_cursor
 ```
 
 **Platforms:** `save_cursor_pos` and `restore_cursor_pos` work everywhere.
-`hide_cursor` and `show_cursor` are macOS only and are no-ops on Linux and
-Windows.
+`hide_cursor` and `show_cursor` are macOS only; on Linux and Windows the daemon
+refuses them with `ERR_NOT_SUPPORTED`.
 
 `save_cursor_pos` records the cursor position; `restore_cursor_pos` returns it
 there and consumes the record. `hide_cursor` and `show_cursor` control the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -89,7 +89,7 @@ Accepted by every command.
 | [`grid`](#neru-grid)                                         | Coordinate grid navigation      | Yes | All |
 | [`recursive_grid`](#neru-recursive_grid)                     | Recursive cell navigation       | Yes | All |
 | [`scroll`](#neru-scroll)                                     | Vim-style scrolling             | Yes | All |
-| [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | macOS · Linux |
+| [`monitor_select`](#neru-monitor_select)                     | Jump the cursor to a display    | Yes | All |
 | [`mode`](#neru-mode)                                         | Enter a mode declared in config | Yes | All |
 | [`action`](#actions)                                         | One-shot mouse/scroll/key input | Yes | All ² |
 | [`run`](#neru-run)                                           | Run several actions in order    | Yes | All |
@@ -99,7 +99,7 @@ Accepted by every command.
 | [`toggle-cursor-follow-selection`](#neru-toggle-cursor-follow-selection) | Toggle cursor follow | Yes | All |
 | [`toggle-screen-share`](#neru-toggle-screen-share)           | Hide overlays while sharing     | Yes | macOS |
 | [`roles`](#neru-roles)                                       | List the role vocabulary        | No  | All |
-| [`services`](#neru-services)                                 | Manage the system service       | No  | macOS · Linux |
+| [`services`](#neru-services)                                 | Manage the system service       | No  | All |
 | [`docs`](#neru-docs)                                         | Open documentation in a browser | No  | All |
 
 ¹ Element discovery quality differs by platform: a full accessibility tree on
@@ -496,8 +496,7 @@ Move the cursor to another display.
 neru monitor_select [flags]
 ```
 
-**Platforms:** macOS · Linux. Not implemented on Windows, where it returns
-`ERR_NOT_SUPPORTED`.
+**Platforms:** all. Requires more than one display.
 
 Opens a labelled panel on each display. Typing a label moves the cursor to that
 display. The current display is excluded.
@@ -588,10 +587,14 @@ a hotkey binding string, or `neru action` directly.
 | Toggle   | `left_mouse_toggle`, `right_mouse_toggle`, `middle_mouse_toggle`                                    |
 | Movement | `move_mouse`, `move_mouse_relative`, `move_monitor`                                                 |
 | Scroll   | `scroll`, `scroll_up`, `scroll_down`, `scroll_left`, `scroll_right`, `page_up`, `page_down`, `go_top`, `go_bottom` |
-| Mode     | `reset`, `backspace`, `move_cell`, `cycle_hint`, `wait_for_mode_exit`                               |
+| Mode     | `reset`, `backspace`, `move_cell`, `cycle_hint`, `search_hints` ³, `wait_for_mode_exit`             |
 | Cursor   | `save_cursor_pos`, `restore_cursor_pos`, `hide_cursor`, `show_cursor`                               |
 | Keys     | `feed`                                                                                              |
 | Timing   | `sleep` — [hotkey bindings only](#action-sleep-hotkey-bindings-only)                                |
+
+³ `search_hints` opens the hint search field in hints mode. It has no
+`neru action` subcommand; bind it as `"action search_hints"` in a mode's
+`[hotkeys]` or run it through `neru run` / `neru macro`.
 
 **Mode `--action` accepts mouse-button names only** — the click, press, release,
 and toggle rows above, plus the deprecated `mouse_down` / `mouse_up`. Every
@@ -605,7 +608,7 @@ Every action not listed here behaves identically on macOS, Linux, and Windows.
 
 | Action                            | macOS | Linux | Windows | Note                                                     |
 | --------------------------------- | :---: | :---: | :-----: | -------------------------------------------------------- |
-| `hide_cursor`, `show_cursor`      | Yes   | No    | No      | Uses a Quartz API with no cross-platform equivalent; a no-op elsewhere. |
+| `hide_cursor`, `show_cursor`      | Yes   | No    | No      | Uses a Quartz API with no cross-platform equivalent; elsewhere the daemon returns `ERR_NOT_SUPPORTED`. |
 | `move_monitor`                    | Yes   | Yes   | Yes     | Requires more than one display.                           |
 
 The injection mechanism differs per platform even where behaviour matches:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1100,6 +1100,26 @@ The `label_direction` setting controls how multi-character hint labels are enume
 
 You can also mix directions per-app via `[hints.app_configs]` or per-activation via `neru hints --label-direction`. See the [per-app config table](#per-app-config) and [CLI reference](CLI.md#neru-hints).
 
+### Default Hotkeys
+
+```toml
+[hints.hotkeys]
+"Escape"    = "idle"
+"/"         = "action search_hints"
+"Backspace" = "action backspace"
+"Tab"       = "action cycle_hint"
+"Shift+Tab" = "action cycle_hint --backward"
+"Shift+L"   = "action left_click"
+"Shift+R"   = "action right_click"
+"Shift+M"   = "action middle_click"
+"Shift+I"   = "action left_click --state down"
+"Shift+U"   = "action left_click --state up"
+"Up"        = "action move_mouse_relative --dx=0 --dy=-10"
+"Down"      = "action move_mouse_relative --dx=0 --dy=10"
+"Left"      = "action move_mouse_relative --dx=-10 --dy=0"
+"Right"     = "action move_mouse_relative --dx=10 --dy=0"
+```
+
 ### Per-App Config
 
 | Field                        | Type   | Description                                                                                                                                                                               |
@@ -1161,7 +1181,7 @@ reported once.
 its distinct characters, `sublayer_keys` included, so the grid is built from `ab`
 whether you wrote `ab`, `aab` or `aAb`. That is why the repeat is worth a warning
 rather than a refusal: what it costs is a shorter alphabet, not a cell you can see
-and cannot click. Note that dropping repeats is also what can leave a set too
+and cannot click. Dropping repeats is also what can leave a set too
 short — `characters = "aa"` has one usable character, so it falls back to `a-z`,
 and both facts are reported.
 
@@ -1191,6 +1211,25 @@ one subgrid cell unlabelled, which is visible on screen in a way a warning is no
 [grid.ui]
 font_size = 10
 border_width = 1
+```
+
+### Default Hotkeys
+
+```toml
+[grid.hotkeys]
+"Escape"    = "idle"
+"`"         = "toggle-cursor-follow-selection"
+"Space"     = "action reset"
+"Backspace" = "action backspace"
+"Shift+L"   = "action left_click"
+"Shift+R"   = "action right_click"
+"Shift+M"   = "action middle_click"
+"Shift+I"   = "action left_click --state down"
+"Shift+U"   = "action left_click --state up"
+"Up"        = "action move_mouse_relative --dx=0 --dy=-10"
+"Down"      = "action move_mouse_relative --dx=0 --dy=10"
+"Left"      = "action move_mouse_relative --dx=-10 --dy=0"
+"Right"     = "action move_mouse_relative --dx=10 --dy=0"
 ```
 
 ### Per-App Config
@@ -1282,6 +1321,25 @@ label_background = false
 sub_key_preview = false
 ```
 
+### Default Hotkeys
+
+```toml
+[recursive_grid.hotkeys]
+"Escape"    = "idle"
+"`"         = "toggle-cursor-follow-selection"
+"Space"     = "action reset"
+"Backspace" = "action backspace"
+"Shift+L"   = "action left_click"
+"Shift+R"   = "action right_click"
+"Shift+M"   = "action middle_click"
+"Shift+I"   = "action left_click --state down"
+"Shift+U"   = "action left_click --state up"
+"Up"        = "action move_mouse_relative --dx=0 --dy=-10"
+"Down"      = "action move_mouse_relative --dx=0 --dy=10"
+"Left"      = "action move_mouse_relative --dx=-10 --dy=0"
+"Right"     = "action move_mouse_relative --dx=10 --dy=0"
+```
+
 ### Per-App Config
 
 ```toml
@@ -1322,6 +1380,15 @@ Keyboard-driven scrolling.
 "PageUp"  = "action page_up"
 "d"       = "action page_down"
 "PageDown"= "action page_down"
+"Shift+L" = "action left_click"
+"Shift+R" = "action right_click"
+"Shift+M" = "action middle_click"
+"Shift+I" = "action left_click --state down"
+"Shift+U" = "action left_click --state up"
+"Up"      = "action move_mouse_relative --dx=0 --dy=-10"
+"Down"    = "action move_mouse_relative --dx=0 --dy=10"
+"Left"    = "action move_mouse_relative --dx=-10 --dy=0"
+"Right"   = "action move_mouse_relative --dx=10 --dy=0"
 ```
 
 ### Per-App Config
@@ -1367,7 +1434,7 @@ Interactive display picking mode. Shows per-monitor overlay badges labelled with
 | `border_radius`        | `-1` (auto)   | Badge corner radius               |
 | `padding_x`            | `-1` (auto)   | Horizontal padding                |
 | `padding_y`            | `-1` (auto)   | Vertical padding                  |
-| `border_width`         | `0`           | Badge border width                |
+| `border_width`         | `1`           | Badge border width                |
 | `background_color`     | derived       | Badge fill color                  |
 | `text_color`           | derived       | Label text color                  |
 | `matched_text_color`   | derived       | Partially-typed label text color  |
@@ -1394,7 +1461,7 @@ subtitle_font_family = ""
 border_radius = -1
 padding_x = -1
 padding_y = -1
-border_width = 0
+border_width = 1
 backdrop_color = ""
 
 [monitor_select.hotkeys]
@@ -1734,7 +1801,7 @@ accelerates. An empty `accel_targets` while `accel_enabled = true` is rejected
 for the same reason.
 
 `accel_enabled = true` while `enabled = false` is not an error: acceleration
-shapes a glide, so with no glide to shape it simply does nothing, and refusing
+shapes a glide, so with no glide to shape it does nothing, and refusing
 the file would stop you turning held-key behaviour off without also unwinding
 the settings under it. `neru config validate` reports it as a warning instead.
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -10,7 +10,9 @@ covers both sides of that:
 
 Every claim in Part 1 is derived from code under `internal/adapter/` and
 `internal/app/`. **If this document and the code disagree, the code wins**,
-and the disagreement is a bug worth fixing here.
+and the disagreement is a bug worth fixing here. Where a row or footnote names
+a file, test or ADR, that is where the full mechanism is written down; this
+document states the claim and points there.
 
 **Related:** [Architecture](./ARCHITECTURE.md) · [Linux setup](./LINUX_SETUP.md) ·
 [Linux desktops](./LINUX_DESKTOPS.md) · [Development Guide](./DEVELOPMENT.md)
@@ -81,14 +83,13 @@ action and command means what it means on macOS, and
 kept. The headless-sway and native `windows-latest` CI jobs gate merges.
 
 **Both stay Beta anyway**, because parity is a claim about coverage and Stable
-is a claim about reliability. Fourteen Linux capabilities landed in a fortnight
-and seventeen Windows tickets in one push, on platforms the maintainer does not
-daily-drive, each proven by a CI job rather than by use.
+is a claim about reliability: the Linux and Windows work landed fast, on
+platforms the maintainer does not daily-drive, each piece proven by a CI job
+rather than by use.
 
 **A Beta platform moves to Stable** after six consecutive releases in which no
 bug specific to it is filed, meaning one a macOS user would not also hit. Count
-bugs *filed* in that window, not ones still open at the end of it. The rule is
-the same for Linux and Windows; only the label changes:
+bugs *filed* in that window, not ones still open at the end of it:
 
 ```bash
 since=$(gh release view <tag-six-back> --json publishedAt --jq .publishedAt)
@@ -97,7 +98,7 @@ gh issue list --state all --label "platform: linux" --label bug \
 ```
 
 The query returns candidates. A person still has to discount cross-platform
-bugs wearing a platform label, and it sees only what triage labelled.
+bugs wearing a platform label.
 
 ### Per-platform
 
@@ -116,9 +117,8 @@ bugs wearing a platform label, and it sees only what triage labelled.
 Linux is not one target. The live backend is detected once at startup from
 `XDG_CURRENT_DESKTOP`, `WAYLAND_DISPLAY`, and `DISPLAY`
 ([backend_linux.go](../internal/adapter/platform/backend_linux.go)). This is
-the only place the compositor *family* is decided. The `display_server` field
-in `neru info` and `neru doctor` is derived from the matched row rather than
-read from the environment a second time.
+the only place the compositor *family* is decided; the `display_server` field
+in `neru doctor` is derived from the matched row.
 
 | Backend                | Detected when                                                          | Status            |
 | ---------------------- | ---------------------------------------------------------------------- | ----------------- |
@@ -133,19 +133,15 @@ read from the environment a second time.
 > **The daemon refuses to start on `wayland-other` and `unknown`.**
 > `platform.NewSystemPort` returns `CodeNotSupported` for both, and that is
 > the first step of daemon startup, so the daemon exits instead of starting
-> degraded. `wayland-gnome` is refused the same way when the session exposes no
-> X server (`DISPLAY` unset), because Mutter implements no `wlr-layer-shell`
-> and the overlay there is an override-redirect window on Xwayland.
+> degraded. `wayland-gnome` is refused the same way when `DISPLAY` is unset,
+> because Mutter implements no `wlr-layer-shell` and the overlay there is an
+> override-redirect window on Xwayland.
 >
-> **GNOME reads as the KDE column below with four differences.** The overlay
-> is X11 + Cairo on Xwayland; focused-app identity, the app watcher and the
-> window origin come from the Neru GNOME Shell extension rather than a
-> compositor protocol (a stub until the extension is loaded, which takes one
-> re-login after the daemon installs it); the cursor position is re-learned
-> through an Xwayland discovery window rather than a layer-shell one; and
-> keyboard capture is the evdev proxy alone, with no compositor fallback.
-> Everything else, libei input, portal capture and consent, uinput scroll,
-> the dark-mode portal, is the KDE mechanism unchanged.
+> **GNOME reads as the KDE column below with four differences**: the overlay is
+> X11 + Cairo on Xwayland; focused-app identity, the app watcher and the window
+> origin come from the Neru GNOME Shell extension (a stub until one re-login
+> after the daemon installs it); the cursor position is re-learned through an
+> Xwayland discovery window; and keyboard capture is the evdev proxy alone.
 > [LINUX_DESKTOPS.md](LINUX_DESKTOPS.md#gnome-wayland) carries the measured
 > detail.
 
@@ -200,25 +196,15 @@ answer.
 | **Key feed (`neru key`)**     | ✅ `CGEventPost`         | ✅ uinput               | ✅ uinput / virtual-keyboard | ✅ uinput               | ✅ `SendInput`               |
 | **Service management (`neru services`)** | ✅ launchd user agent | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ⚠️ systemd user unit only ² | ✅ Task Scheduler logon task |
 
-¹ **Font resolution.** Every platform resolves font *families* through the OS.
-A family somebody named resolves to **that name**, not to what the platform
-would render in its place. The exception is a family the platform can see is
-missing: Linux (fontconfig) and Windows (GDI) send it to the sans baseline,
-DejaVu Sans and Segoe UI, rather than to the platform's own substitute, so
-`font_family = "Arial"` without Arial installed reports DejaVu Sans on Linux and
-not the Liberation Sans that `fc-match Arial` names. A missing serif or mono
-family lands on the sans baseline too. macOS, the non-CGO Linux build, and a
-build whose fontconfig or GDI cannot be consulted check nothing and hand the
-name to NSFont / Cairo / DirectWrite, which substitute at draw time.
-
-The generic names are the same on all three: `sans`, `sans serif`, `serif`,
-`mono`, `monospace` and the empty string, matched ignoring case, whitespace and
-the separator between words (`internal/adapter/platform/fontgeneric`, ADR 0007).
-What each resolves to is the platform's own: Helvetica Neue / Times New Roman /
-Menlo on macOS, DejaVu Sans / Serif / Sans Mono on Linux, Segoe UI / Cambria /
-Consolas on Windows. Resolved answers are cached under the family name
-exactly as written (`internal/adapter/platform/fontcache`); the non-CGO Linux
-build re-derives each time.
+¹ **Font resolution.** Every platform resolves font *families* through the OS,
+and a named family resolves to **that name**. A family the platform can see is
+missing goes to the sans baseline (DejaVu Sans on Linux, Segoe UI on Windows)
+rather than to the platform's own substitute; macOS and the non-CGO Linux build
+check nothing and let NSFont / Cairo substitute at draw time. The generic names
+`sans`, `serif`, `mono` (and their spelling variants, and the empty string)
+resolve to each platform's own faces
+(`internal/adapter/platform/fontgeneric`, ADR 0007); answers are cached per
+family name (`internal/adapter/platform/fontcache`).
 
 ² **Service management** is the one row whose limit is not the display server:
 it needs **systemd**, on every Linux backend. runit, OpenRC and s6 get
@@ -226,149 +212,73 @@ it needs **systemd**, on every Linux backend. runit, OpenRC and s6 get
 rather than a gap. See "Service management on Linux" below.
 
 ³ **Smooth scroll granularity.** `smooth_scroll` animates everywhere, but only
-some primitives can send a step shorter than a wheel notch. `zwlr_virtual_pointer_v1.axis`
-carries a fractional value and wlroots forwards it as a continuous
-`wl_pointer.axis`; libei's `ei_device_scroll_delta` is pixel-precise and KWin
-forwards it the same way. X11 core scrolling is buttons 4 to 7, one notch per
-event, and the XTEST pointer has no scroll valuator for the smooth XI2 path.
-Windows sits with Wayland: `MOUSEEVENTF_WHEEL` counts 120ths of `WHEEL_DELTA`,
-so the animator steps in 120ths of a notch.
-
-**What a `scroll_step` number means differs per platform.** macOS posts
-pixel-unit wheel events, so a step of 50 scrolls 50 px. Windows sends
-`WHEEL_DELTA` units at 4 per pixel (120 per 30 px notch), so 50 px is 200
-units, delivered exactly, and an application accumulates the fraction the
-way it does for a high-resolution wheel. Linux converts at 30 px per notch on
-each path that sends notches (uinput, the wlroots virtual pointer, XTest) and
-rounds to the nearest, never fewer than one. 44 px is one notch, 45 px and
-the default 50 px are two, 500 px is seventeen. Rounding rather than
-truncation is what keeps a 59 px step from travelling no further than a
-30 px one. On KDE, libei carries the pixel delta as is.
-
-**So X11 animates in notches, and a scroll that rounds to one notch is not
-animated at all.** A `scroll_step` under 45 pixels on X11 arrives as the
-single wheel click it always did. From two notches up, the default included,
-the same eased curve applies as everywhere else, and the animated scroll
-travels the same notch count as the unanimated one.
-
-Neru sends the same distance on every backend. On Wayland the animated path
-spends that distance as a continuous delta where the unanimated one spends it
-as notches, and an application may scale the two differently, so switching the
-animation on can change how far a scroll reaches. Wayland steps declare axis
-source `continuous` rather than `wheel`, because a wheel source invites a
-toolkit to round the fraction back to a detent. Measured on wlroots (sway) by
-`TestScrollAtCursor_DeliversSubNotchStepsWithSmoothScroll`, which maps a real
-`xdg-shell` window and reads what the compositor delivers. **The X11 and KDE
-conclusions are read from the sources named above and are not measured on
-hardware**, and neither is the uinput `REL_WHEEL_HI_RES` route: the
-headless-sway job reads no input devices at all.
+some primitives can send a step shorter than a wheel notch: the wlroots virtual
+pointer and libei carry fractional deltas, Windows counts 120ths of a notch,
+and X11 core scrolling is one notch per event. Neru sends the same distance on
+every backend; Linux paths that send notches convert at 30 px per notch and
+round to the nearest, never fewer than one, so on X11 a `scroll_step` under 45
+px is a single unanimated click and everything from two notches up gets the
+same eased curve as elsewhere. Wayland steps declare axis source `continuous`
+so toolkits do not round the fraction back to a detent. The wlroots behaviour is
+measured by `TestScrollAtCursor_DeliversSubNotchStepsWithSmoothScroll`; the
+X11 and KDE conclusions are read from the protocol sources and not measured on
+hardware.
 
 ⁴ **Native hint-search field.** Only macOS has a platform text control that
 owns keyboard focus and brings the system input method with it. Everywhere else
 the query is read from the event tap's key stream, so dead keys and IME
-composition do not work there and a hint search takes plain characters. The
-search *badge* on screen is a different thing and every platform draws one:
-`hints.search_input_ui.*` means what it says on all three, and the badge never
-captures a key.
+composition do not work there. The search *badge* is a different thing: every
+platform draws one, and `hints.search_input_ui.*` means the same on all three.
 
 ⁵ **Screen capture** is taken per backend rather than through the desktop
 portal everywhere, because a consent picker in front of a hint refresh is a
-latency and consent-fatigue regression the blessed stack has no need to pay.
-X11 reads the root window back with `XGetImage`; wlroots compositors implement
-`wlr-screencopy-unstable-v1`, which needs no consent. Windows reads the desktop
-DC with `BitBlt` into a 32-bit DIB, no consent gate and no cgo; the process is
-per-monitor-v2 DPI aware, so the frame is the region's size in physical pixels.
-
-**KWin implements neither**, so KDE Plasma pays the portal: pixels come from an
-`org.freedesktop.portal.ScreenCast` session over PipeWire (`libpipewire-0.3`, a
-required [build dependency](./LINUX_SETUP.md#build-dependencies) on every Linux
-install). It is a **permission** rather than a missing capability, which is why
-`CheckScreenCapturePermission` and `RequestScreenCapturePermission` report the
-portal's real consent state there and "no gate" on X11, wlroots and Windows. The
-prompt is paid once: the grant is persisted with a restore token in
-`$XDG_STATE_HOME/neru/screen-cast.token`, and only the mode handler's
-permission preflight can raise the dialog, never a capture. Sources are
-requested as monitors with the cursor left out; windows are not asked for,
-because a window stream carries no position. A monitor stream carries one only
-on a Plasma that speaks screencasting v6, which no release up to 6.5 does.
-Every shipped Plasma names a size alone, so each stream is placed at capture
-time on the `wl_output` it belongs to, by KWin's `mapping_id` where the portal
-sends one and otherwise by size, pairing identical monitors off in announcement
-order. A stream nothing can place is taken to start at the origin, which is
-right for a single display.
-
-Capture is a **region** operation on every backend, and what comes back covers
-exactly the region asked for. A rectangle that leaves the screen, is
-degenerate, or spans two monitors on Wayland (`wlr-screencopy` and a ScreenCast
-stream are one output each) **fails** instead of coming back clipped, because a
-clipped frame carries nothing that says where its own top-left is. On KDE a
-region on a monitor the user chose not to share fails the same way. On a scaled
-Wayland output the frame is in physical pixels, larger than the logical region
-by the scale factor, as a Retina capture is on macOS.
+latency regression the blessed stack has no need to pay. X11 uses `XGetImage`,
+wlroots `wlr-screencopy`, Windows `BitBlt`, none of which asks consent. **KWin
+implements neither**, so KDE pays the portal: an
+`org.freedesktop.portal.ScreenCast` session over PipeWire, a
+[required build dependency](./LINUX_SETUP.md#build-dependencies). It is a
+**permission** rather than a missing capability: the grant is persisted with a
+restore token under `$XDG_STATE_HOME/neru/`, only the mode handler's permission
+preflight can raise the dialog, and `CheckScreenCapturePermission` reports the
+real consent state there and "no gate" elsewhere. Capture is a **region**
+operation on every backend, and a region that leaves the screen, spans two
+Wayland outputs, or lies on a monitor the user declined to share **fails**
+rather than coming back clipped, because a clipped frame cannot say where its
+own top-left is. Scaled outputs return physical pixels, as Retina does on
+macOS. How KDE streams are placed on outputs is in
+[portal_screencast.go](../internal/adapter/platform/linux/portal_screencast.go).
 
 ⁶ **Vision on Linux and Windows is text-only**, and permanently so. macOS runs
-three Vision requests (text, rectangles, saliency); an OCR engine answers the
-first. `hints.vision.detect_rectangles` and the four `rectangle_*` options are
-therefore declared macOS-only. The `contour` strategy is a separate,
-dependency-free detector on every platform, not an implementation of
-`detect_rectangles`. The other fourteen `hints.vision.*` options are read on
-Linux as on macOS; Windows reads eleven, because its engine reports no per-word
-confidence and the three `*_confidence` floors are declared inert there.
+three Vision requests (text, rectangles, saliency); an OCR engine answers only
+the first, so `hints.vision.detect_rectangles` and the four `rectangle_*`
+options are declared macOS-only. The `contour` strategy is a separate,
+dependency-free detector on every platform. On Linux the engine is
+**tesseract**, linked through cgo and required at build time, with its language
+data resolved at use (`TESSDATA_PREFIX`, then the distribution paths); a missing
+`eng.traineddata` gets `CodeNotSupported` naming that file. On Windows it is
+**`Windows.Media.Ocr`** through raw vtables with no CGO
+(`platform/windows/ocr.go`); it needs the OCR language pack for one of the
+account's languages, reports no per-word confidence (so the three
+`*_confidence` floors are declared inert there), and caps images at 2600 px,
+which Neru downsamples to and scales back from. Recognized text is screen
+content: never logged, never written to disk.
 
-On Linux the engine is **tesseract**, linked through `#cgo pkg-config` like
-every other native dependency, and required: a missing `libtesseract.so` stops
-the daemon before any Neru code runs. Its **language data is a separate
-package**, resolved at use (`TESSDATA_PREFIX` first, then the distribution
-paths); a machine with no `eng.traineddata` gets `CodeNotSupported` naming that
-file from `VisionPort.Health` and from `DetectElements`. Recognition runs at
-word level for `--split-word` and at line level otherwise, LSTM engine in
-sparse-text segmentation, scoped to the focused window (full-display OCR takes
-seconds where one window takes tens of milliseconds). Recognized text is screen
-content: never logged, never written to disk, cleared out of the engine before
-each recognition returns.
-
-On Windows the engine is **`Windows.Media.Ocr`**, the WinRT engine every
-Windows 10 and 11 desktop ships, driven through raw vtables with no CGO
-(`platform/windows/ocr.go`). It needs the **OCR language pack** for one of the
-account's profile languages, which a language's *Basic typing* feature
-installs; without one `VisionPort.Health` and `DetectElements` report
-`CodeNotSupported` naming that remedy. The engine caps both image dimensions at
-2600 pixels, so a wider frame (any 4K monitor) is box-averaged down by the
-smallest whole factor that fits and the word boxes scaled back. Every word
-scores one.
-
-⁷ **Modifiers on injected input (X11 and Windows).** An X11 pointer event
-carries the modifiers the server records as **held**, and a `SendInput` mouse
-event carries whatever the keyboard holds, so an injected click or scroll used
-to pick up whatever the user's hand was on: `Ctrl+J` bound to a plain
-`scroll_down` sent ctrl+scroll, which most applications read as zoom, and a
-hotkey chord still held while a hint was chosen made the click a ctrl+click.
-Neru reads the live key state (`XQueryKeymap`, `GetAsyncKeyState`), releases
-the modifiers the injection would otherwise falsify, presses the ones asked
-for, and undoes both when done, held across every chunk of an animated
-scroll. A modifier both held
-and asked for is left alone. A drag holds that state for as long as the button
-is down: press and release are separate calls, and the release undoes what the
-press set up. Letting go of a modifier inside that window is not observed, and
-the modifier reads as held until pressed and released once more. Restoring is
-the deliberate bias, since the opposite drops a modifier the user is still
-holding.
+⁷ **Modifiers on injected input (X11 and Windows).** An X11 pointer event and a
+`SendInput` mouse event both carry whatever modifiers the keyboard currently
+holds, so a hotkey chord still held while a hint was chosen used to make the
+click a ctrl+click. Neru reads the live key state (`XQueryKeymap`,
+`GetAsyncKeyState`), releases the modifiers the injection would falsify,
+presses the ones asked for, and undoes both when done, held across every chunk
+of an animated scroll and across a drag until its release. Restoring is the
+deliberate bias, since the opposite drops a modifier the user is still holding.
 
 ⁸ **Tray and notifications.** The tray icon carries the paused state on every
-platform, since it is the only place a user can see that Neru is paused without
-pressing a key. macOS swaps two template glyphs. Hosts that render icon bytes
-literally (SNI hosts on Linux, the Win32 notification area) get the brand tile
-desaturated toward grey, derived from the running tile
-([icon/paused.go](../internal/adapter/systray/icon/paused.go)) so the two never
-drift. Hover text is the tray icon's own ("Neru - Running" / "Neru - Paused")
-on all three. Per-item menu tooltips exist nowhere: `com.canonical.dbusmenu`
-defines no per-item tooltip property, so `MenuItem.SetTooltip` in
-[systray/linux/systray.go](../internal/adapter/systray/linux/systray.go) is
-empty by protocol, as is its Win32 twin.
-
-**Notifications on Windows are balloon tips on that tray icon** (`Shell_NotifyIcon`
-with `NIF_INFO`, rendered as toasts on Windows 10 and 11), because WinRT toasts
-need an AppUserModelID an unpackaged exe does not have. With
+platform: macOS swaps template glyphs, SNI hosts and the Win32 notification
+area get a desaturated tile derived from the running one
+([icon/paused.go](../internal/adapter/systray/icon/paused.go)). Per-item menu
+tooltips exist nowhere, because `com.canonical.dbusmenu` defines none.
+**Notifications on Windows are balloon tips on that tray icon**, because WinRT
+toasts need an AppUserModelID an unpackaged exe does not have; with
 `systray.enabled = false` there is nothing to attach a tip to, so
 `ShowNotification` reports `CodeNotSupported` naming that reason. Alerts are
 `MessageBoxW` and do not depend on the tray.
@@ -376,119 +286,78 @@ need an AppUserModelID an unpackaged exe does not have. With
 ⁹ **Hyprland modified scroll.** With a virtual-keyboard modifier held, a
 `zwlr_virtual_pointer` scroll produces no event on Hyprland
 ([#1474](https://github.com/y3owk1n/neru/pull/1474)), so there the modifier
-goes out on the virtual keyboard and the scroll on the uinput wheel, leaving
-the compositor to merge seat state across two devices. A `wl_display.sync`
-confirms the modifier landed before the first notch is written; the release
-waits a fixed period, since nothing reports how far a compositor has read a
-kernel evdev device. `smooth_scroll` still applies, in whole notches, because
-`REL_WHEEL` has no sub-notch value. The compositor is named from
-`XDG_CURRENT_DESKTOP` beside the backend detection, not from
-`HYPRLAND_INSTANCE_SIGNATURE`, which says which compositor is reachable rather
-than which one is running.
+goes out on the virtual keyboard and the scroll on the uinput wheel, in whole
+notches. The compositor is named from `XDG_CURRENT_DESKTOP` beside the backend
+detection.
 
-¹⁰ **windows/arm64 overlay.** The Direct2D binding is pure Go and passes floats
-through Go's stdcall shim, which mirrors integer arguments into the XMM
-registers on amd64 only, so windows/arm64 builds the GDI surface alone
-(`platform/windows/overlay_dcomp_other.go`).
+¹⁰ **windows/arm64 overlay.** The Direct2D binding passes floats through Go's
+stdcall shim, which handles them on amd64 only, so windows/arm64 builds the GDI
+surface alone (`platform/windows/overlay_dcomp_other.go`).
 
 ### Notes on the ⚠️ entries
 
 **Focused app on Wayland.** wlroots and KWin resolve the focused window through
-`wlr-foreign-toplevel-management`, which exposes the window's **app_id** (the
-identity per-app config keys on) but not its PID, because a Wayland client
-cannot read another client's process credentials.
-`SystemPort.FocusedApplicationPID` best-effort matches the app_id against
-`/proc`; with no match it returns `CodeNotSupported` carrying the app_id rather
-than a fabricated number. A session where *nothing* is focused is a different
-answer and says so.
+`wlr-foreign-toplevel-management`, which exposes the window's **app_id** (what
+per-app config keys on) but not its PID. `SystemPort.FocusedApplicationPID`
+best-effort matches the app_id against `/proc` and otherwise returns
+`CodeNotSupported` carrying the app_id rather than a fabricated number.
 
-**An unfocused desktop is not a failure on X11 either.** `_NET_ACTIVE_WINDOW`
-has four ways of not giving a window, reported as two kinds. Nothing focused is
-`CodeNotSupported`, so callers degrade as they do on Wayland. A display no
-*live* EWMH window manager owns (the `_NET_SUPPORTING_WM_CHECK` handshake, not
-the leftover `_NET_SUPPORTED`), a failed read and a malformed property are
-`CodeActionFailed`, each naming which. `_NET_WM_PID` splits the same way: a live
-window that publishes no pid is `CodeNotSupported`, a window that closed under
-the query is `CodeActionFailed`. `FocusedWindowBounds` on X11 tells the same two
-apart: nothing focused is `found=false` with no error, the rest is an error, so
-a caller widening to the active screen knows whether it is obeying an answer or
-guessing.
+**An unfocused desktop is not a failure on X11 either.** Nothing focused is
+`CodeNotSupported`, so callers degrade as they do on Wayland; a display with no
+live EWMH window manager, a failed read or a malformed property is
+`CodeActionFailed` naming which. `FocusedWindowBounds` tells the same two apart
+(`found=false` with no error versus an error), so a caller widening to the
+active screen knows whether it is obeying an answer or guessing.
 
-**App watcher.** macOS gets focus changes from an NSWorkspace observer. Linux
-subscribes to a backend focus-change fd (`linux.SubscribeFocusedApp`: X11 event
-fd, or the wlroots toplevel manager) in `appwatcher/platform_linux.go` and
-re-samples on each wake, with a 3s safety re-sample against coalesced events;
-with no fd it polls `FocusedAppID` every 400ms. The identity is `WM_CLASS` (X11)
-or `app_id` (Wayland). A sibling goroutine watches a display-configuration fd
-and dispatches screen-parameter changes, so monitor hotplug regenerates
-overlays. Windows installs an `EVENT_SYSTEM_FOREGROUND` hook through
-`SetWinEventHook` on its own message-loop thread
-(`appwatcher/platform_windows.go`) and resolves each foreground HWND to the
-**executable path**, the identity `GetForegroundWindow` already gives. Display
-changes come from a hidden top-level window receiving `WM_DISPLAYCHANGE` and
-`WM_DPICHANGED` (`platform/windows/display_watcher.go`), coalesced into one
-screen-parameters event. On both, only activate, deactivate and screen-params
-are emitted; launch, terminate and Mission Control stay macOS-only.
+**App watcher.** macOS observes NSWorkspace. Linux subscribes to a backend
+focus-change fd (X11 event fd, or the wlroots toplevel manager) in
+`appwatcher/platform_linux.go`, with a 3s safety re-sample and a 400ms poll
+when no fd exists; the identity is `WM_CLASS` or `app_id`. Windows installs an
+`EVENT_SYSTEM_FOREGROUND` hook on its own message-loop thread
+(`appwatcher/platform_windows.go`) and reports the **executable path**; display
+changes arrive through a hidden window receiving `WM_DISPLAYCHANGE`
+(`platform/windows/display_watcher.go`). On both, only activate, deactivate and
+screen-params are emitted; launch, terminate and Mission Control stay
+macOS-only.
 
 **Global hotkeys on Wayland.** No Wayland protocol lets an ordinary client
 register a global hotkey, so Neru matches chords itself on the evdev keyboard
-proxy, the one reader of `/dev/input/event*` that the in-mode capture also runs
-on ([global_hotkey_cgo.go](../internal/adapter/eventtap/linux/global_hotkey_cgo.go),
-[evdev_proxy_cgo.go](../internal/adapter/eventtap/linux/evdev_proxy_cgo.go),
+proxy that the in-mode capture also runs on
+([global_hotkey_cgo.go](../internal/adapter/eventtap/linux/global_hotkey_cgo.go),
 [ADR 0014](adr/0014-the-wayland-keyboard-is-a-proxy.md)). With `/dev/uinput`
-writable the proxy holds every keyboard from daemon launch, whether or not
-`[hotkeys]` is set, and re-emits it through a uinput device of its own, so a
-matched chord is withheld from the focused app. It never keeps a keyboard that
-has a key down: a daemon or a remapper started from a compositor binding is
-held once the binding's modifier comes up, so no modifier is left stuck in the
-compositor's picture of the device. Without it the
-proxy reads passively, the chord matches all the same, and the app receives it
-too. The process needs read access to `/dev/input` (the `input` group) and a
-CGO build; a `CGO_ENABLED=0` build gets a stub whose `Start` reports
-`CodeNotSupported` ([global_hotkey_nocgo.go](../internal/adapter/eventtap/linux/global_hotkey_nocgo.go)).
-Either way Neru warns once with the remedy that fits and names the fallback,
-binding `neru <mode>` in the compositor. While a mode is active the proxy hands
-every press to the mode session, which is what **A global chord while a mode is
-active** below is about.
+writable the proxy holds every keyboard from daemon launch and re-emits it
+through a uinput device, so a matched chord is withheld from the focused app; it
+never grabs a keyboard that has a key down, so no modifier is left stuck.
+Without uinput it reads passively and the app receives the chord too. It needs
+the `input` group and a CGO build; a `CGO_ENABLED=0` build gets a stub whose
+`Start` reports `CodeNotSupported`. Either way Neru warns once with the remedy
+and names the fallback, binding `neru <mode>` in the compositor.
 
 **Native alerts on Linux.** Notifications and alerts both go to the session's
-freedesktop notification daemon over D-Bus, in pure Go, so a `CGO_ENABLED=0`
-build shows them too. An alert differs from a notification only in insistence:
-critical urgency and no expiry. It is *not* modal: `NSAlert` stops the world and
-returns which button was pressed, and no Wayland or X11 client can do that, so
-a Linux alert informs rather than asks and callers take the safe default. A
-missing config file therefore starts Neru on built-in defaults and says so,
-instead of offering create / defaults / quit. Delivery needs a notification
-daemon (mako, dunst, or the desktop's own) running or D-Bus activatable, which
-`neru doctor` counts as present. With none, `ShowNotification` and `ShowAlert`
-report `CodeNotSupported`, `neru doctor` downgrades the notifications row with
-what to install, and the two startup alerts fall back to stderr.
+freedesktop notification daemon over D-Bus, in pure Go. An alert is a
+notification with critical urgency and no expiry, and it is *not* modal: no
+Wayland or X11 client can stop the world and return a button, so a Linux alert
+informs and callers take the safe default (a missing config file starts Neru on
+defaults and says so). With no notification daemon, both report
+`CodeNotSupported`, `neru doctor` says what to install, and the two startup
+alerts fall back to stderr.
 
-**Service management on Linux.** The mechanism is a **systemd user unit**
-anchored on `graphical-session.target`: `After=` and `WantedBy=` it because
-every backend needs a display server, `PartOf=` it so a logout/login cycle
-restarts the daemon instead of leaving an orphan. Coverage is systemd and no
-other init system. What answers the question is systemd's runtime marker,
-`/run/systemd/system`, not `systemctl` on `PATH`, which ships in packages
-installed on machines running something else. Where the unit is written and
-how a user drives it: [LINUX_SETUP.md](./LINUX_SETUP.md#systemd-user-service).
+**Service management on Linux.** A **systemd user unit** anchored on
+`graphical-session.target` (`After=`, `WantedBy=`, `PartOf=`), so a logout and
+login restarts the daemon rather than orphaning it. Coverage is systemd and no
+other init: the check is systemd's runtime marker `/run/systemd/system`, not
+`systemctl` on `PATH`. Where the unit lives and how to drive it:
+[LINUX_SETUP.md](./LINUX_SETUP.md#systemd-user-service).
 
 **Smooth cursor animation on Linux.** Off by default; opt in with
-`smooth_cursor.move_mouse_enabled`. When enabled, `SystemAdapter.MoveCursorToPoint`
-routes through `smoothCursorAnimator`
-([mouse_animator.go](../internal/adapter/platform/linux/mouse_animator.go)):
-one worker goroutine samples the current position, then steps the per-backend
-warp (XTest / `zwlr_virtual_pointer` / libei) toward the target by linear
-interpolation, coalescing so the latest target wins, and `WaitForCursorIdle`
-blocks until it settles. It covers the flows macOS animates (grid cursor-follow,
-`move_mouse`, selection moves); clicks stay instant. On Wayland the start point
-comes from the client-side cursor cache, so a stale read skews the glide path,
-never the landing point. Relative (hjkl) moves animate over
-`smooth_cursor.relative_movement_duration`: X11 and KDE extend the absolute
-animator's endpoint, wlroots drains the delta in integer chunks through native
-relative motion ([relative_animator.go](../internal/adapter/platform/linux/relative_animator.go))
-so it never reads the position cache. Position-dependent actions settle the
-in-flight animation before acting.
+`smooth_cursor.move_mouse_enabled`. One worker goroutine steps the per-backend
+warp toward the target by linear interpolation, latest target wins, and
+`WaitForCursorIdle` blocks until it settles
+([mouse_animator.go](../internal/adapter/platform/linux/mouse_animator.go)).
+Relative moves on wlroots drain the delta through native relative motion
+([relative_animator.go](../internal/adapter/platform/linux/relative_animator.go))
+so they never read the position cache. Clicks stay instant, and
+position-dependent actions settle the animation before acting.
 
 ---
 
@@ -496,9 +365,8 @@ in-flight animation before acting.
 
 Every action type in [action.go](../internal/domain/action/action.go), click,
 per-button down/up/toggle, absolute and relative moves, drag-while-held and
-scroll, is dispatched through the shared `InfraAXClient.PerformAction`. The
-dispatch, the action set and the mode logic are platform-neutral Go; only the
-final injection primitive differs:
+scroll, is dispatched through the shared `InfraAXClient.PerformAction`. Only
+the final injection primitive differs:
 
 | Platform              | Primitive                                                                    |
 | --------------------- | ---------------------------------------------------------------------------- |
@@ -509,31 +377,23 @@ final injection primitive differs:
 | Windows               | `SendInput` / `SetCursorPos`                                                  |
 
 Scrolling behaves the same on all three platforms, both axes included. Windows
-posts `MOUSEEVENTF_HWHEEL` for the horizontal component with the sign flipped,
-because Win32 reads a positive horizontal notch as right where the others read
-it as left.
+posts `MOUSEEVENTF_HWHEEL` with the sign flipped, because Win32 reads a positive
+horizontal notch as right where the others read it as left.
 
-**Modifiers on a scroll** reach the primitive by two routes, because only one
-primitive has a field for them. macOS stamps `CGEventSetFlags` on the scroll
-event, always (the empty set included, since a NULL-source event inherits the
-ambient session modifiers otherwise) and on every chunk of an animation. The
-other three press the real key, scroll, and release it. On X11 that key event
-feeds back into Neru's own `XGrabKeyboard`, so each one is announced to the
-event tap before it goes out and consumed on the way back in; otherwise
-`sticky_modifiers` latched a modifier nobody pressed. On Wayland the modifier
-can only go out on the virtual keyboard (libei on KDE), so a modified scroll
-skips the uinput batch and goes out on the wlroots/libei seat, everywhere but
-Hyprland (footnote ⁹). A path with no backend to press through answers
+**Modifiers on a scroll** reach the primitive by two routes. macOS stamps
+`CGEventSetFlags` on every scroll event and every chunk of an animation. The
+other three press the real key, scroll, and release it; on X11 that key event is
+announced to Neru's own event tap first so `sticky_modifiers` does not latch it,
+and on Wayland it goes out on the virtual keyboard (libei on KDE), everywhere
+but Hyprland (footnote ⁹). A path with no backend to press through answers
 `CodeNotSupported`; none scrolls unmodified and reports success.
 
 **Held mouse buttons.** Press and release are separate actions, so every
 backend keeps a [`mousestate.Tracker`](../internal/adapter/platform/mousestate/tracker.go)
-recording which buttons are down, where, and with which modifiers. It drives
-three behaviors identically everywhere: toggle actions resolve against it,
-`EnsureMouseUp` releases every held button when Neru returns to idle, and on
-macOS it selects the drag event type for cursor moves. Quartz requires
-`kCGEventLeftMouseDragged` and friends with a matching button number instead of
-`kCGEventMouseMoved`; X11, Wayland and Windows warp the pointer and let the
+recording which buttons are down, where, and with which modifiers. Toggle
+actions resolve against it, `EnsureMouseUp` releases every held button when
+Neru returns to idle, and on macOS it selects the drag event type for cursor
+moves, which Quartz requires; the other platforms warp the pointer and let the
 compositor infer the drag.
 
 ---
@@ -552,106 +412,61 @@ compositor infer the drag.
 | **Capture files**     | `eventtap/darwin/`     | `eventtap/linux/x11_cgo.go` | `eventtap/linux/evdev_proxy_cgo.go`, `evdev_session_cgo.go`, `wayland_cgo.go` | `eventtap/windows/` |
 | **Hotkey files**      | `hotkeys/darwin/`      | `hotkeys/linux/x11_cgo.go`  | `hotkeys/linux/manager.go` + `eventtap/linux/global_hotkey_cgo.go` | `hotkeys/windows/` |
 
-There is no separate Wayland hotkey file. The Wayland path lives in the common
-`hotkeys/linux/manager.go`, which delegates to the evdev listener in the
-eventtap package.
+There is no separate Wayland hotkey file: `hotkeys/linux/manager.go` delegates
+to the evdev listener in the eventtap package.
 
-**A held global hotkey.** Every manager implements `HotkeyReleaseRegistrar`,
-and reports a hold as one press and one release however long it lasts, which is
-what `[held_repeat]` repeats between. macOS folds autorepeat in the per-hotkey
-tap. The evdev proxy fires the release when the chord's key comes up, whether or
-not the modifier is still down by then. X11 asks the server for detectable
-autorepeat on both of its connections (`XkbSetDetectableAutoRepeat`), so a held
-key is repeated `KeyPress` events and one `KeyRelease` rather than the
-release/press pairs that would end the hold at the server's repeat rate; the
-in-mode tap needs the same, or the mode's own held repeat stops after its first
-tick. `RegisterHotKey` reports the press only, so the Windows registry registers
-with `MOD_NOREPEAT` and reads the key through `GetAsyncKeyState` every 10 ms
-from the `WM_HOTKEY` until it reads up. The poll runs only while a hotkey is
-held; the other source of releases, the `WH_KEYBOARD_LL` hook, sits on every
-keystroke for as long as it is installed, and installing it for the daemon's
-lifetime would put a hook procedure on the idle path to pay for a release only a
-held hotkey needs.
+**A held global hotkey.** Every manager implements `HotkeyReleaseRegistrar` and
+reports a hold as one press and one release, which is what `[held_repeat]`
+repeats between. macOS folds autorepeat in the per-hotkey tap; the evdev proxy
+fires the release when the chord's key comes up; X11 asks the server for
+detectable autorepeat (`XkbSetDetectableAutoRepeat`) on both connections so a
+held key is repeated presses and one release; `RegisterHotKey` reports the
+press only, so Windows registers with `MOD_NOREPEAT` and polls
+`GetAsyncKeyState` every 10 ms while a hotkey is held.
 
 **A global chord while a mode is active.** A `[hotkeys]` binding keeps working
-from inside a mode on macOS, Windows and Linux Wayland, and each gets there its
-own way, because whichever mechanism can see the chord has to be the only one
-that runs it. macOS hands it back: the in-mode tap looks the chord up in the
-hotkey table the app pushed into it and returns the event untouched, so the
-per-hotkey tap fires ([eventtap_darwin.m](../internal/adapter/platform/darwin/eventtap_darwin.m)).
-Windows does the same for a Ctrl/Alt/Cmd chord one layer up: the low-level hook
-passes it on without dispatching and leaves it to `RegisterHotKey`. Both are
-told which chords the backend *took* rather than which ones the
-configuration asked for (`Deps.PublishRegisteredHotkeys`,
-[hotkey.go](../internal/app/keybinding/hotkey.go)), because a chord another
-process owns is refused and handing that one back would drop it. Linux cannot
-hand it to anybody: X11's in-mode capture is an exclusive `XGrabKeyboard`, and
-the Wayland proxy hands every press to the mode session while one is open. So
-there the chord reaches the mode handler, which resolves the global table
-itself after the active mode's own table
-([keymap.go](../internal/app/modes/keymap.go), `settledKeymaps`). That fallback
-is shared code, unreachable on the two platforms whose taps hand the
-chord back. Only chords carrying Ctrl/Alt/Cmd fall back: a bare key inside a
-mode is a hint label or a grid cell key.
+from inside a mode on every platform, each its own way, because whichever
+mechanism can see the chord has to be the only one that runs it. macOS and
+Windows hand the chord back: the in-mode tap returns it untouched so the
+per-hotkey tap or `RegisterHotKey` fires, and both are told which chords the
+backend *took* rather than which the configuration asked for
+(`Deps.PublishRegisteredHotkeys`, [hotkey.go](../internal/app/keybinding/hotkey.go)).
+Linux cannot hand it to anybody, since X11's capture is an exclusive
+`XGrabKeyboard` and the Wayland proxy owns every press while a mode is open, so
+there the mode handler resolves the global table itself after the mode's own
+([keymap.go](../internal/app/modes/keymap.go), `settledKeymaps`). Only chords
+carrying Ctrl/Alt/Cmd fall back: a bare key inside a mode is a hint label or a
+grid cell key. One consequence shared by both Linux backends: while a mode is
+open, a chord bound in the *compositor* rather than in `[hotkeys]` cannot fire.
 
-**X11 assembles chords from the keysym.** The X11 in-mode tap names the key
-from the **keysym** `XLookupString` returns rather than from the string,
-because with Ctrl held the two disagree (`Ctrl+C` gives `\x03` as a string and
-`XK_c` as a keysym), and prepends the modifiers it tracks (`x11ChordFromLookup`,
-[x11_cgo.go](../internal/adapter/eventtap/linux/x11_cgo.go)). The keysym is
-state-resolved, so Shift has chosen the level the same way
-`xkb_state_key_get_one_sym` does for the evdev reader, which is what makes both
-backends call `Shift+;` the same thing. A keysym outside Latin-1 falls back to
-the character the server produced, unprefixed. One consequence of the exclusive
-capture is shared by both Linux backends: while a mode is open, a chord bound
-in the *compositor* rather than in `[hotkeys]` cannot fire.
-
-**One key, one name.** Both Linux readers of `/dev/input`, the in-mode tap and
-the passive hotkey listener, resolve a scan code through the compositor's XKB
-keymap (`keyName`/`modifierName`,
-[evdev_xkb_cgo.go](../internal/adapter/eventtap/linux/evdev_xkb_cgo.go)). They
-have to agree, because only one of them sees any given press. Following the
-keymap is what makes a binding mean the key that *types* that character, and
-what lets XKB options like `ctrl:swapcaps` reach Neru's own bindings. **On a
+**One key, one name.** Both Linux readers of `/dev/input` resolve a scan code
+through the compositor's XKB keymap
+([evdev_xkb_cgo.go](../internal/adapter/eventtap/linux/evdev_xkb_cgo.go)), and
+the X11 tap names the key from the state-resolved **keysym** rather than the
+string `XLookupString` returns, so all backends call `Shift+;` the same thing
+and XKB options like `ctrl:swapcaps` reach Neru's own bindings. **On a
 non-QWERTY layout this decides which physical key a `[hotkeys]` chord answers**:
-the one bearing that character on the active layout. The keysym is named by
-the character it types when it types one, and by keysym name only otherwise
-(`neru_xkb_keysym_name`,
-[wayland_keymap.c](../internal/adapter/platform/linux/wayland_keymap.c)), the
-rule the X11 tap applies too. Shift has already chosen the level by the time a
-keysym exists, and the shifted level's *name* is not its character (`Shift+[`
-is `braceleft`), so a hand-written name table could never be complete. The one
-named key XKB renames under Shift, `ISO_Left_Tab`, folds back to `Tab` on both
-backends, which is what lets the default `Shift+Tab` hint binding fire. Fold
-rows are keyed by the name libxkbcommon answers, the first one
-`xkbcommon-keysyms.h` lists: the page keys are `Prior` and `Next`, and a row
-keyed `Page_Up` was dead.
+the one bearing that character on the active layout. A keysym is named by the
+character it types when it types one, and by keysym name otherwise
+([wayland_keymap.c](../internal/adapter/platform/linux/wayland_keymap.c)); the
+one key XKB renames under Shift, `ISO_Left_Tab`, folds back to `Tab`, which is
+what lets the default `Shift+Tab` hint binding fire.
 
 **Modifier passthrough (Wayland evdev, and Windows).** While a mode is active
-Neru captures the keyboard exclusively, so shortcuts it does not bind
-(`Ctrl+C`, `Ctrl+Tab`) are swallowed. With `general.passthrough_unbounded_keys`,
-unbound Ctrl/Alt/Cmd chords reach the focused app instead. On the Wayland evdev
-backend the proxy keyboard is the only keyboard the compositor sees, so a chord
-the mode lets through is re-emitted on it together with the modifiers the user
-is physically holding, and each stays the compositor's until released
-(`evdevSession.handlePress` and `evdevProxy.forwardWithheld`). It is **not**
-available on X11 (an `XGrabKeyboard` routes Neru's own XTest events back to
-itself, and `XSendEvent` is ignored by most apps) nor on the rare wl-keyboard
-fallback, which has no injection path. The platform column cannot say "Linux,
-except X11", so a configuration that turns passthrough on under X11 warns once
-at load, in the same voice as the parity warning, and `neru doctor` lists the
-option and its two dependents in its `platform_support` row
-(`config.X11InertWords`). Windows needs no re-injection: a
-`WH_KEYBOARD_LL` hook forwards or blocks each event on its own
-(`eventtap/windows/tap.go`, `handleKey`). Classification (blacklist,
-mode-intercepted keys, the mode's own hotkeys, and the global chords it falls
-back to) and the post-passthrough hint refresh are shared in
-[passthrough.go](../internal/app/modes/passthrough.go); only the final
-re-injection is backend-specific. `general.should_exit_after_passthrough` exits
-the mode after a passthrough. Both lists are re-derived whenever a mode opens,
-the configuration is replaced, hints refresh after a passthrough, or the
-focused application changes under an open mode, which keeps per-app overrides
-meaningful after passing `Cmd+Tab` through.
+Neru captures the keyboard exclusively, so shortcuts it does not bind are
+swallowed. With `general.passthrough_unbounded_keys`, unbound Ctrl/Alt/Cmd
+chords reach the focused app instead: the Wayland proxy re-emits them on its
+uinput keyboard together with the modifiers the user is physically holding, and
+the Windows `WH_KEYBOARD_LL` hook forwards or blocks each event on its own. It
+is **not** available on X11 (an `XGrabKeyboard` routes Neru's own XTest events
+back to itself, and `XSendEvent` is ignored by most apps) nor on the wl-keyboard
+fallback; since the platform column cannot say "Linux, except X11", turning it
+on under X11 warns once at load and `neru doctor` lists the option in its
+`platform_support` row (`config.X11InertWords`). Classification and the
+post-passthrough hint refresh are shared in
+[passthrough.go](../internal/app/modes/passthrough.go); only the re-injection
+is backend-specific. `general.should_exit_after_passthrough` exits the mode
+after a passthrough.
 
 ---
 
@@ -668,84 +483,59 @@ meaningful after passing `Cmd+Tab` through.
 | **Strategies**          | `axtree` (default), `vision` and `contour`, incl. per-app overrides | `axtree`, `vision` (text only) and `contour` | `axtree`, `vision` (text only) and `contour` |
 | **Popovers / menus**    | ✅ dedicated detection                      | ⚠️ only if inside the active frame's subtree       | 🟡                                   |
 
-macOS builds the richest tree by a wide margin: multiple window and system
-sources, per-app strategy overrides, the Vision fallback, and deduplication.
-Linux walks a single tree with tesseract beside it. Windows fetches the
-window's control-view tree in one cached UI Automation query with
-`Windows.Media.Ocr` beside it; the ⚠️ is the control view, since an element a
-provider exposes only in the raw view is not a hint, and the answer is a role
-or filter default, never a per-app branch.
+macOS builds the richest tree by a wide margin. Linux walks a single AT-SPI
+tree with tesseract beside it. Windows fetches the window's control-view tree in
+one cached UI Automation query with `Windows.Media.Ocr` beside it; the ⚠️ is
+the control view, since an element a provider exposes only in the raw view is
+not a hint, and the answer is a role or filter default, never a per-app branch.
 
-**Linux is ⚠️, not a stub.** `atspi.Client` enables assistive-tech mode, finds
-the active frame, and walks it (`ClickableNodes`) emitting native AT-SPI role
-names. Configured roles are resolved into that vocabulary at config load
-(`element.ResolveRoles`), so both sides of the filter speak AT-SPI. The
-`BuildTree` stub in `native/linux/tree.go` is the macOS-style tree API and is
-**not** on the Linux hints path. The ⚠️ is coverage: it depends on each app
-exposing AT-SPI.
+**Linux is ⚠️, not a stub.** `atspi.Client` walks the active frame emitting
+native AT-SPI role names, and configured roles are resolved into that vocabulary
+at config load (`element.ResolveRoles`). The ⚠️ is coverage: it depends on each
+app exposing AT-SPI.
 
 **Chromium and Electron apps on Linux** do not expose their web-content tree
-over AT-SPI by default, and unlike macOS there is no per-app attribute Neru can
-toggle to force it. The result is a frame with a single empty child. Launch the
-app with `--force-renderer-accessibility`. Native GTK/Qt apps and Firefox need
-no flag. This is Chromium behavior, not a Neru limitation.
+over AT-SPI by default, and there is no per-app attribute Neru can toggle to
+force it. Launch the app with `--force-renderer-accessibility`. Native GTK/Qt
+apps and Firefox need no flag. This is Chromium behavior, not a Neru limitation.
 
 **Picking the active frame.** The AT-SPI `ACTIVE` state cannot be trusted
-across applications. On wlroots compositors the focused window can report
-`ACTIVE=false` while background frames report `ACTIVE=true`. On X11,
-Chromium/Electron frames report `ACTIVE=true` whatever `_NET_ACTIVE_WINDOW`
-says. So Neru matches the AT-SPI frame against the focused window's identity
-instead. On Wayland that is the compositor's app_id and title from
-`wlr-foreign-toplevel-management`. On X11 it is the active window's WM_CLASS
-and `_NET_WM_NAME`. Both pairs are read as one snapshot
-(`linux.FocusedAppIdentity`). The `ACTIVE`/`SHOWING` heuristic is still the
-fallback when no identity is available (GNOME without the extension), and on
-X11 for an application whose AT-SPI name does not match its WM_CLASS
-(`findActiveFrame` in `atspi/scan.go`).
+across applications (wlroots can report the focused window `ACTIVE=false`;
+Chromium on X11 reports `ACTIVE=true` regardless), so Neru matches the AT-SPI
+frame against the focused window's identity instead: app_id and title on
+Wayland, WM_CLASS and `_NET_WM_NAME` on X11, read as one snapshot
+(`linux.FocusedAppIdentity`). The `ACTIVE`/`SHOWING` heuristic remains the
+fallback when no identity is available (`findActiveFrame` in `atspi/scan.go`).
 
 **Window-origin offset on Wayland.** A Wayland client cannot know its own
 on-screen position, so AT-SPI reports element coordinates relative to the
 window. Neru offsets them by the focused window's screen origin, supplied by a
 compositor-specific `windowOriginSource`
-([window_origin.go](../internal/adapter/accessibility/atspi/window_origin.go))
-chosen from the detected backend:
+([window_origin.go](../internal/adapter/accessibility/atspi/window_origin.go)):
 
 | Compositor | Source                                                       | Limits                                                                                                                    |
 | ---------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| KDE / KWin | KWin script pushing focused-window geometry over D-Bus ([platform/kwin](../internal/adapter/platform/kwin)) | Reports on activation, on the focused window's geometry changing, and on it going away, so the cache follows a drag, resize, tile or maximize and empties when the desktop is focused. Neru watches `org.kde.KWin` on the session bus and reinstalls the script when KWin restarts. A drag reports its final rectangle, so a mid-drag query reads the start position. |
-| niri       | `niri msg -j focused-window` / `focused-output`              | Floating and fullscreen windows only. **Tiled** windows, including a maximized column, expose no on-screen position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are misaligned there. |
+| KDE / KWin | KWin script pushing focused-window geometry over D-Bus ([platform/kwin](../internal/adapter/platform/kwin)) | Reports on activation and on the focused window moving, resizing or going away; Neru reinstalls the script when KWin restarts. A drag reports its final rectangle. |
+| niri       | `niri msg -j focused-window` / `focused-output`              | Floating and fullscreen windows only. **Tiled** windows expose no on-screen position ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are misaligned there. |
 | Sway       | `swaymsg -t get_tree`, focused node `rect` + `window_rect`   | none                                                                                                                       |
 | Hyprland   | `hyprctl -j activewindow` `at` / `size`                      | none                                                                                                                       |
-| GNOME      | GNOME Shell extension reporting the focused window's frame over D-Bus ([platform/gnomeshell](../internal/adapter/platform/gnomeshell)) | Reports on focus change and on the focused window moving, resizing or retitling. The daemon installs and enables the extension; the shell loads it at the next login. Identity is checked as on KDE. |
+| GNOME      | GNOME Shell extension reporting the focused window's frame over D-Bus ([platform/gnomeshell](../internal/adapter/platform/gnomeshell)) | The daemon installs and enables the extension; the shell loads it at the next login. |
 | Anything else (X11, River, Wayfire) | none                                                | X11 needs none, AT-SPI already reports screen coordinates there. The rest report no origin, so hints stay window-relative. |
 
-Each source verifies the reported window size matches the AT-SPI frame (a
-focus change can race the query) and is best-effort: an unavailable origin
-degrades to unoffset coordinates rather than misplacing hints. The KWin source
-checks identity as well as size, because its rectangle is a cache: the script
-reports `resourceClass`, `resourceName` and caption, the AT-SPI frame carries
-the app_id and title it was selected with, and a disagreement means the cached
-rectangle belongs to a different window. Both comparisons are written to be
-sure before they refuse (reverse-DNS app_id spelling tolerated, caption prefix
-accepted in either direction, an identity neither side reported is not a
-mismatch), because a false reject unoffsets hints that were placed correctly.
-
-**A compositor that did not answer is not a compositor with no origin.** The
-three CLI sources go through
+Each source verifies the reported window matches the AT-SPI frame (size on
+all of them, identity as well on KWin and GNOME, because their rectangle is a
+cache) and is best-effort: an unavailable origin degrades to unoffset
+coordinates rather than misplacing hints. The CLI sources go through
 [platform/compositorcli](../internal/adapter/platform/compositorcli), which
-reports a CLI that could not be run, exited non-zero, timed out or printed
-something undecodable as a failure naming the command, at `warn`. A compositor
-that *did* answer and has no position to give (nothing focused, a tiled niri
-window) stays a plain not-found, so ordinary layout never warns.
+warns when a compositor could not be run or answered garbage and stays quiet
+when it answered with no position (nothing focused, a tiled niri window).
 
 **The same sources answer `FocusedWindowBounds`,** which scopes vision and
-contour detection and `neru action move_mouse --window` to the focused window.
-The KWin arm of
-[system_focused_window.go](../internal/adapter/platform/linux/system_focused_window.go)
-reads the cache the AT-SPI path offsets by, and the wlroots arms use the same
-`compositorcli` query. A Wayland compositor with no source (River, Wayfire)
-reports `CodeNotSupported` there rather than "no focused window": both send the
-caller to the active screen, but only one says so.
+contour detection and `neru action move_mouse --window` to the focused window
+([system_focused_window.go](../internal/adapter/platform/linux/system_focused_window.go)).
+A Wayland compositor with no source (River, Wayfire) reports `CodeNotSupported`
+there rather than "no focused window", so a caller widening to the active
+screen knows why.
 
 ---
 
@@ -824,31 +614,22 @@ mode indicator, sticky-modifier indicator, all pending actions on grid cells,
 backtracking, and every scroll granularity.
 
 > The **cursor-replacement virtual pointer**, drawn when the real cursor is
-> hidden, is separate from the two grid indicators above and is macOS-only:
-> `virtualpointer.Overlay` is a no-op on every non-darwin build, paired with
-> `CGDisplayHideCursor`, which has no equivalent elsewhere.
+> hidden, is separate from the two grid indicators above and is macOS-only,
+> paired with `CGDisplayHideCursor`, which has no equivalent elsewhere.
 
-> **`hints.ui.placement` means the same thing on all three platforms.** `top`
-> puts the badge above the element's centre with an arrow pointing down at it,
-> `center` over it with no arrow, `bottom` below it with an arrow pointing up
-> (the default). Linux and Windows take the offsets and the arrow from one
-> implementation (`adapter/overlay/render/badge.PlaceHint`), so a placement
-> lands on the same pixel on both. macOS computes its own in Objective-C (the
-> deliberate exception ADR 0007 records) with a shorter, wider arrow, so a badge
-> sits a few pixels closer to its element there. On Windows the Win32 surface
-> has no path primitive, so the arrow is a triangle over a slightly larger one
-> in the border colour, which leaves the badge's own edge running across the
-> arrow's base ([#1303](https://github.com/y3owk1n/neru/issues/1303)).
+> **`hints.ui.placement` means the same thing on all three platforms.** Linux
+> and Windows take the offsets and the arrow from one implementation
+> (`adapter/overlay/render/badge.PlaceHint`); macOS computes its own in
+> Objective-C (the exception ADR 0007 records) with a shorter, wider arrow. On
+> Windows the Win32 surface has no path primitive, so the arrow is a triangle
+> over a slightly larger one in the border colour
+> ([#1303](https://github.com/y3owk1n/neru/issues/1303)).
 
 > **`recursive_grid.ui.sub_key_preview` is one drawing on all three platforms**
-> ([#1297](https://github.com/y3owk1n/neru/issues/1297)). Each backend divides
-> the cell by the *next* level's grid dimensions and draws the key that selects
-> each sub-cell in its own place; the centre sub-cell of an odd-by-odd division
-> is left blank for the cell's own label, and nothing is previewed at the
-> deepest level. `sub_key_preview_autohide_multiplier` measures a **sub-cell**,
-> which must reach `sub_key_preview_font_size × multiplier` in both width and
-> height, from one implementation (`recursivegrid.Style.ShowSubKeyPreviewIn`,
-> with the macOS copy held to it by
+> ([#1297](https://github.com/y3owk1n/neru/issues/1297)), and
+> `sub_key_preview_autohide_multiplier` measures a **sub-cell** from one
+> implementation (`recursivegrid.Style.ShowSubKeyPreviewIn`, with the macOS
+> copy held to it by
 > `internal/architecture/sub_key_preview_autohide_rule_test.go`).
 
 ---
@@ -935,19 +716,15 @@ whatever the [Capability Matrix](#capability-matrix) currently reports
 | Screen-sharing hide                       | macOS    | `platform/darwin/overlay_darwin.m`                      | NSWindow sharing level is a Quartz concept                    |
 | Secure input detection                    | macOS    | `platform/darwin/secureinput.go`                        | `CGSessionCopyCurrentDictionary`, a private API; neither X11 nor Wayland has the concept |
 
-Two entries left this table in ADR 0013 and neither is coming back. **Smooth
-scroll animation** now animates on every backend, with X11 limited to whole
-notches (footnote ³), and a limit on one backend is that backend's documented
-limit rather than an exclusive. The **Vision (OCR) hint strategy** was met on
-Linux by tesseract and on Windows by `Windows.Media.Ocr`; its
-rectangle-detection half has no OCR answer, so `detect_rectangles` and the four
-`rectangle_*` options stay macOS-only and are declared as such.
+Two entries left this table in ADR 0013 and neither is coming back: **smooth
+scroll animation** now animates on every backend (X11 in whole notches,
+footnote ³), and the **Vision (OCR) hint strategy** was met by tesseract and
+`Windows.Media.Ocr`, with only its rectangle-detection half staying macOS-only.
 
 Linux and Windows have no exclusive *user-facing* features. Their unique
-elements (evdev, `zwlr_virtual_pointer`, libei, the Wayland sync-cursor
-surface, `WH_KEYBOARD_LL`, `RegisterHotKey`, SDF rendering) are mechanisms
-serving cross-platform features, listed in the
-[Capability Matrix](#capability-matrix).
+elements (evdev, `zwlr_virtual_pointer`, libei, `WH_KEYBOARD_LL`,
+`RegisterHotKey`, SDF rendering) are mechanisms serving cross-platform
+features, listed in the [Capability Matrix](#capability-matrix).
 
 ---
 
@@ -967,29 +744,25 @@ None. Parity is complete on the blessed stack;
 The `input`-group membership Wayland global hotkeys need is a host setup step
 rather than a gap: Neru warns with the remedy when the listener cannot start,
 and [LINUX_SETUP.md](./LINUX_SETUP.md#install-time-environment-adjustments)
-carries it as install-time item 2.
+carries it.
 
 **Not Linux gaps**, and deliberately so: secure input detection and system
 cursor hide are [Platform Exclusives](#platform-exclusives); GNOME Wayland
-needing a shell extension for its focused window is Mutter's decision, not a
-capability gap; X11 modifier
-passthrough is impossible for the display server (`XGrabKeyboard` is
-all-or-nothing and `XSendEvent` is ignored by most applications); and
-`neru services` on a non-systemd init is a stated boundary.
+needing a shell extension for its focused window is Mutter's decision; X11
+modifier passthrough is impossible for the display server; and `neru services`
+on a non-systemd init is a stated boundary.
 
 **The `CGO_ENABLED=0` Linux build is outside the boundary too**, and says so
-itself. It is a distribution convenience: cursor, clicks, scroll, hotkeys,
-keyboard capture, overlay, screen enumeration, display hotplug, focused app,
-`neru key` and the `vision` strategy are all `CodeNotSupported` there, so it
-announces what kind of build it is once at startup, naming what will not work
-and how to leave it ([ADR 0012](./adr/0012-the-first-hour-must-not-lie.md)). A
-CGO build never prints it. The tray, notifications and alerts are pure Go and
-keep working, which is why the build exists.
+itself: cursor, clicks, scroll, hotkeys, keyboard capture, overlay, screen
+enumeration, focused app, `neru key` and the `vision` strategy are all
+`CodeNotSupported` there, so it announces what kind of build it is once at
+startup ([ADR 0012](./adr/0012-the-first-hour-must-not-lie.md)). The tray,
+notifications and alerts are pure Go and keep working, which is why the build
+exists.
 
 **Windows**
 
-None. Parity is complete; the `feed` action and `neru key` inject through
-`SendInput`, the call the pointer and modifier passthrough already use.
+None. Parity is complete.
 
 **Not a Windows gap**: the three `hints.vision.*_confidence` floors are inert
 because `Windows.Media.Ocr` reports no per-word confidence, a boundary of the
@@ -1027,7 +800,6 @@ Read these before changing platform code:
 - [platform/profile.go](../internal/adapter/platform/profile.go): per-subsystem backend family and CGO expectations
 - [ports/system.go](../internal/ports/system.go): the main OS contract, plus the optional-extension pattern
 - [ports/capabilities.go](../internal/ports/capabilities.go) and [capability_presets.go](../internal/ports/capability_presets.go): the capability registry `neru doctor` reports
-- [ports/font.go](../internal/ports/font.go): the FontResolver port
 - [architecture/platform_slots_test.go](../internal/architecture/platform_slots_test.go): the file-layout rules, as executable checks
 - [ARCHITECTURE.md](./ARCHITECTURE.md) and the root [AGENTS.md](../AGENTS.md) conventions
 
@@ -1036,8 +808,7 @@ Linux files the package already has before writing anything. A
 single-platform directory such as `internal/adapter/platform/linux/` drops the
 OS token and splits by backend (`system_x11_cgo.go`,
 `system_wayland_wlroots_cgo.go`), while a mixed package carries it
-(`internal/adapter/platform/factory_linux.go`,
-`internal/adapter/overlay/backend_linux.go`).
+(`internal/adapter/platform/factory_linux.go`).
 
 ## The Three Tiers
 
@@ -1069,12 +840,11 @@ Current ports: `SystemPort`, `AccessibilityPort`, `OverlayPort`, `EventTapPort`,
 `AppWatcherPort`, `SystrayPort`, `FontResolver`.
 
 Optional extensions (Tier 3): `RelativeCursorMover`, `CursorSynchronizer`
-and `InstantCursorMover` on `SystemPort`, `HotkeyReleaseRegistrar` and `HotkeyHealthReporter` on
-`HotkeyPort`, `OverlayKeyboardPassthroughReporter` on `EventTapPort`,
-`OverlayCapabilityReporter` on `OverlayPort`, and `SyntheticModifierSink` on
-the `tap.Tap` backend contract (Linux only, declared in a `_linux.go` file
-beside `Tap`, because only X11 cannot tell its own injected key events apart
-from the user's).
+and `InstantCursorMover` on `SystemPort`, `HotkeyReleaseRegistrar` and
+`HotkeyHealthReporter` on `HotkeyPort`, `OverlayKeyboardPassthroughReporter`
+on `EventTapPort`, `OverlayCapabilityReporter` on `OverlayPort`, and
+`SyntheticModifierSink` on the `tap.Tap` backend contract (Linux only, because
+only X11 cannot tell its own injected key events apart from the user's).
 
 [`keyfeed`](../internal/adapter/keyfeed/) is the reference example: shared
 normalization untagged in `keyfeed.go`, one unexported `postKey` per platform,
@@ -1096,8 +866,8 @@ func platformActiveScreenBounds() image.Rectangle { return image.Rectangle{} }
 
 Keeping them unexported is the whole point: an exported one becomes another
 package's dependency, and the seam has quietly become a badly-specified port.
-Examples: `accessibility/priming_*.go`, `accessibility/supplementary_*.go`,
-`appwatcher/platform_*.go`, `ipc/transport_unix.go`.
+Examples: `accessibility/priming_*.go`, `appwatcher/platform_*.go`,
+`ipc/transport_unix.go`.
 
 ### Tier 3: Optional port extension
 
@@ -1116,16 +886,12 @@ type RelativeCursorMover interface {
 if mover, ok := s.system.(ports.RelativeCursorMover); ok { /* fast path */ }
 ```
 
-Two rules:
-
-- **Declare it in `ports`.** An interface defined in the consuming package is
-  undiscoverable to a contributor on another platform.
-- **The caller must have a working fallback.** An optional extension is an
-  optimization or a platform-native shortcut, never the only path.
-
-Adapters opting in should assert it: `var _ ports.RelativeCursorMover =
-(*SystemAdapter)(nil)`, so a signature drift fails to compile instead of
-silently downgrading the platform to the generic path.
+Two rules: **declare it in `ports`**, since an interface defined in the
+consuming package is undiscoverable to a contributor on another platform, and
+**the caller must have a working fallback**, since an optional extension is an
+optimization, never the only path. Adapters opting in assert it
+(`var _ ports.RelativeCursorMover = (*SystemAdapter)(nil)`) so a signature
+drift fails to compile instead of silently downgrading the platform.
 
 ### Not ports
 
@@ -1145,24 +911,14 @@ enforced by [layering_test.go](../internal/architecture/layering_test.go):
 | `internal/{domain,ports,derrors,adapter}` never import `internal/app` | adapters implement ports; the hexagon has no upward edges |
 | app code reaches adapters only through ports        | only the composition root knows which adapter exists |
 
-The third rule has three deliberate escapes, all narrow:
-
-- **Shared vocabulary**: `adapter/ipc` (the CLI/daemon wire protocol),
-  `adapter/logger`, and `adapter/platform` (the SystemPort factory plus the
-  `Profile` that `neru doctor` prints). These are data and plumbing, not OS
-  behavior.
-- **Composition root**: `wiring.go`, `startup_phases.go`, `cmd/neru/main.go`.
-  Wiring adapters to ports is their job.
-- **Build-tagged dispatch**: any `*_darwin.go` / `*_linux*.go` /
-  `*_windows.go` / `*_other.go` file in the app layer is Tier 2.
-
-Anything else is a violation. `knownLayeringExceptions` exists for edges that
-cannot be fixed in the same change; it is **empty**, and a second test fails
-if an entry stops being a real violation, so the list can only shrink.
-`internal/adapter/overlay` carried an entry until #1213 and retired it by
-moving what did not belong above the line (the per-mode `Context` types, which
-are mode state and live in `internal/app/components/`) rather than relocating
-the render models that do belong below it.
+The third rule has three deliberate escapes, all narrow: **shared vocabulary**
+(`adapter/ipc`, `adapter/logger`, and `adapter/platform` for the factory and
+the `Profile` that `neru doctor` prints), the **composition root**
+(`wiring.go`, `startup_phases.go`, `cmd/neru/main.go`), and **build-tagged
+dispatch** files in the app layer, which are Tier 2. Anything else is a
+violation. `knownLayeringExceptions` exists for edges that cannot be fixed in
+the same change; it is **empty**, and a second test fails if an entry stops
+being a real violation, so the list can only shrink.
 
 ## File Layout Rules
 
@@ -1188,37 +944,25 @@ a violation fails `just test` rather than review:
 
 Inside a package that is already one platform (`adapter/*/darwin`,
 `adapter/*/linux`, `adapter/platform/windows`, and so on) the OS token is
-dropped, because the directory carries it. `overlay/linux/wayland_cgo.go` and
-`platform/linux/system_x11_cgo.go` keep only the axes that still vary; a
-`system_linux_x11_cgo.go` inside `platform/linux/` would say linux twice. That
-is why the four Linux backend rows above hold no files today: every Linux
-backend split lives inside a single-platform directory. The rows are the
-spelling to use if a mixed package ever needs one.
-
-The `*_integration_cgo.go` row exists for one situation and should stay rare.
-Go rejects `import "C"` in a `_test.go` file, so an integration test that needs
-C (`accessibility/native/linux/scroll_probe_integration_cgo.go`, mapping a
-Wayland window to measure what a compositor delivers) puts it in a non-test
-file. The `integration` term keeps that file out of every product build, and
-the C stays inline in the cgo preamble, because a `.c` file beside it would
-compile into the package unconditionally.
+dropped, because the directory carries it: `overlay/linux/wayland_cgo.go`, not
+`overlay/linux/overlay_linux_wayland_cgo.go`. That is why the four Linux
+backend rows hold no files today; they are the spelling to use if a mixed
+package ever needs one. The `*_integration_cgo.go` row exists because Go
+rejects `import "C"` in a `_test.go` file; the `integration` term keeps such a
+file out of every product build, and the C stays inline in the cgo preamble.
 
 What the guardrail test checks:
 
-- A file constrained to exactly one GOOS must carry that OS as a name token. A
-  `tree.go` that is secretly `//go:build darwin` is invisible to anyone
-  scanning the directory.
+- A file constrained to exactly one GOOS must carry that OS as a name token.
 - A file whose constraint is a pure negation is a fallback and must be named
   `*_other.go`. `_stub.go`, `_default.go`, `_fallback.go`, `_noop.go` and
   friends are rejected: one slot, one spelling.
 - A file gated on cgo must say so: `*_cgo.go` or `*_nocgo.go`.
-- Every file in a **single-platform package** declares its OS tag. The set of
-  exempt directories is derived from the tree: a directory earns the exemption
-  when every file in it targets the same one OS.
+- Every file in a **single-platform package** declares its OS tag; the exempt
+  set is derived from the tree, not listed.
 - Every relative `#include` resolves
-  ([cgo_includes_test.go](../internal/architecture/cgo_includes_test.go)). A
-  broken include is invisible to `go vet` and to `just check-cross`, since
-  `CGO_ENABLED=0` skips the file.
+  ([cgo_includes_test.go](../internal/architecture/cgo_includes_test.go)),
+  which `go vet` and `just check-cross` cannot see under `CGO_ENABLED=0`.
 
 Two rules that save review cycles: do not invent new ad hoc platform filenames
 when a slot already exists, and do not create empty `darwin` / `linux` /
@@ -1239,8 +983,8 @@ adapter/overlay/{manager, darwin, linux, windows}
 
 The directory names the platform, so the filenames inside do not have to, and
 `ls` answers "what do I touch for Wayland?". The parent package keeps the port
-adapter and a small build-tagged factory, usually ten lines, which is the only
-place that knows which implementation exists.
+adapter and a small build-tagged factory, the only place that knows which
+implementation exists.
 
 ### When a backend does not earn a package
 
@@ -1253,44 +997,28 @@ file to open.
 
 ### Giving a capability its own packages
 
-A package that reads as "shared code plus platform files" is usually one
-generic shell specialised by build-tagged concrete types. Creating a backend
-package for it is three moves in order:
-
-1. **Find the seam.** List the methods the shell calls on the platform type.
-2. **Extract the contract into a leaf package** (`accessibility/ax`,
-   `eventtap/tap`). It has to be a leaf: the backends import it and the factory
-   imports the backends, so anything else is an import cycle.
-3. **Move each platform into a package behind a build-tagged factory.**
-
-When the shell talks to *package-level* symbols rather than to methods on a
-value, alias instead of abstracting. `accessibility/native` works this way:
-each platform's files live in their own package and a build-tagged file aliases
-the four types and binds the functions, leaving the shell platform-agnostic
-without an interface.
-
-Two traps: **named function types do not interchange** (a method taking
-`darwin.Callback` does not satisfy an interface wanting `func(string)`, so put
-callback types in the contract package), and **typed nil** (a factory returning
-a concrete `*T` as an interface hands back a non-nil interface holding a nil
-pointer; `staticcheck` reports this as SA4023).
+Creating a backend package is three moves in order: find the seam (the methods
+the shared shell calls on the platform type), extract that contract into a
+**leaf** package (`accessibility/ax`, `eventtap/tap`; it must be a leaf, since
+the backends import it and the factory imports the backends), then move each
+platform into a package behind a build-tagged factory. When the shell talks to
+package-level symbols rather than methods on a value, alias instead of
+abstracting, as `accessibility/native` does. Two traps: named function types do
+not interchange (put callback types in the contract package), and a factory
+returning a concrete `*T` as an interface hands back a typed nil
+(`staticcheck` SA4023).
 
 ### Where the render models live
 
 `hints.Hint`, `grid.Style` and the other render models sit under
-`adapter/overlay/render/` rather than in the domain, because `hints.Hint`,
-`hints.StyleMode` and `hints.Overlay` are one concept every backend needs all
-three of, and splitting them by layer produces two packages named `hints`.
-Nothing above the overlay names them any more (#1213). The per-mode `Context`
-types, which are mode state rather than render models, live in
-`internal/app/components/{hints,grid,recursivegrid}`.
-
-`grid.Style`, `recursivegrid.Style` and `hints.StyleMode` are each declared
-once for every platform. Their fields hold the values the configuration writes,
-and the packed-ARGB and float forms Cairo and GDI want are accessors that
-convert at the point of use. When a type looks platform-specific, check whether
-it differs in meaning or only in representation; the second kind belongs in an
-accessor.
+`adapter/overlay/render/` rather than in the domain, because each is one
+concept every backend needs all of, and splitting them by layer produces two
+packages named `hints`. Nothing above the overlay names them (#1213); the
+per-mode `Context` types, which are mode state, live in
+`internal/app/components/`. Each `Style` is declared once for every platform:
+its fields hold what the configuration writes, and the packed-ARGB and float
+forms Cairo and GDI want are accessors. When a type looks platform-specific,
+check whether it differs in meaning or only in representation.
 
 ## Where To Implement What
 
@@ -1313,53 +1041,24 @@ shared Linux system fallbacks in
 ## Build And Test Commands
 
 Every build and test recipe is catalogued in
-[DEVELOPMENT.md](./DEVELOPMENT.md#common-tasks). Two apply specifically to
-platform work:
+[DEVELOPMENT.md](./DEVELOPMENT.md#common-tasks). What matters for platform
+work:
 
-- `just build && just test-foundation`: the cross-platform-safe baseline to run
-  before touching anything.
-- `just release-ci-linux <arch> <version>` / `just release-ci-windows <arch>
-  <version>`: the tagged release binaries CI produces.
-
-Only the target OS can run `just test` meaningfully, since integration tests
-are tagged per-OS.
-
-### `just build-linux` needs a Linux-targeting C compiler
-
-`just build-windows` cross-compiles from any host, because Windows is a CGO-off
-build. `just build-linux` does not: Linux needs CGO for the X11 and Wayland
-backends, and a macOS clang compiles Go's cgo runtime against the macOS SDK and
-fails. The recipe checks the compiler's target triple up front and refuses with
-the alternatives. From a macOS host, use:
-
-- `just lint-cross`: compiles and lints the linux/amd64 build with CGO on, in
-  Docker
-- `just check-cross`: a fast CGO-off type-check of the Linux and Windows
-  builds, no Docker needed
-- `CGO_ENABLED=0 GOOS=linux GOARCH=<arch> go build ./cmd/neru`: a pure-Go
-  Linux binary. The CGO-only backends compile out, so it is not the shipped
-  product
-
-The guard fails open: it only refuses when the compiler positively reports a
-non-Linux target. The tagged Linux release binaries are built by CI on a native
-Linux runner.
-
-### `just lint` only sees your own platform
-
-golangci-lint honours build tags, so a `//go:build linux` file is invisible to
-`just lint` on macOS. A *build* break in one of those files is caught by
-`just check-cross`, which `just ci` runs. Lint findings still need reproducing:
-
-```bash
-CGO_ENABLED=0 GOOS=linux golangci-lint run ./internal/...
-```
-
-Without cgo, the `*_cgo.go` files are excluded, so anything they alone use is
-reported as `unused` and any helper they alone call is reported by `unparam`.
-Those are artifacts of the no-cgo build; CI lints Linux with cgo enabled.
-Findings in plain-`linux` files are real. The cgo-only paths need a Linux
-toolchain: `just lint-cross` runs them in the Linux CI image, and without
-Docker, CI is the check.
+- `just build && just test-foundation` is the cross-platform-safe baseline to
+  run before touching anything. Only the target OS can run `just test`
+  meaningfully, since integration tests are tagged per-OS.
+- `just build-windows` cross-compiles from any host (CGO off). `just build-linux`
+  does not: Linux needs CGO, and a macOS clang compiles the cgo runtime against
+  the wrong SDK, so the recipe refuses when the compiler reports a non-Linux
+  target. From macOS use `just check-cross` (fast CGO-off type-check of both
+  other targets, no Docker) or `just lint-cross` (the linux/amd64 build with
+  CGO on, in Docker). Tagged Linux release binaries are built by CI on a native
+  runner.
+- `just lint` only sees your own platform, because golangci-lint honours build
+  tags. Reproduce Linux findings with
+  `CGO_ENABLED=0 GOOS=linux golangci-lint run ./internal/...`, ignoring the
+  `unused` and `unparam` reports that come only from the excluded `*_cgo.go`
+  files; the cgo paths need `just lint-cross` or CI.
 
 ## Linux Backend Model
 
@@ -1387,38 +1086,33 @@ around AT-SPI even where other subsystems split.
 
 ### Organize by mechanism, not by desktop
 
-Desktop environments share mechanisms, so the axis that varies is
-usually the mechanism:
+Desktop environments share mechanisms, so the axis that varies is usually the
+mechanism:
 
 - **Input**: KDE, COSMIC and GNOME all use libei (RemoteDesktop portal), and
-  wlroots uses `zwlr_virtual_pointer`. One libei backend serves several DEs.
-  The routing is a runtime probe of the compositor, not a backend switch.
+  wlroots uses `zwlr_virtual_pointer`. One libei backend serves several DEs;
+  the routing is a runtime probe, not a backend switch.
 - **Screen capture**: KDE and COSMIC read the portal's ScreenCast stream, and
   wlroots uses `zwlr_screencopy`.
 - **Overlay**: layer-shell works on KDE, wlroots, and COSMIC. GNOME/Mutter
   lacks it, and its overlay is the X11 backend unchanged, drawn on Xwayland.
-  An override-redirect window is the one surface Mutter stacks above every
-  toplevel without animating or focusing it.
-- **Genuinely DE-specific**: active-window geometry (KWin D-Bus vs Mutter
-  D-Bus) and hotkey registration. These belong in DE-named files such as
-  `internal/adapter/accessibility/atspi/kwin_origin.go`, or in a DE-named
-  package when more than one subsystem needs the same fact:
-  `internal/adapter/platform/kwin` holds the KWin geometry bridge because the
-  AT-SPI window origin and `FocusedWindowBounds` are two readings of it, and
-  `internal/adapter/platform/gnomeshell` holds the GNOME Shell extension
-  bridge for the same two readers plus the app watcher. What
-  is shared across compositors goes in a package named for the mechanism:
+- **Genuinely DE-specific**: active-window geometry and hotkey registration.
+  These go in DE-named files, or in a DE-named package when more than one
+  subsystem needs the same fact: `internal/adapter/platform/kwin` and
+  `internal/adapter/platform/gnomeshell` each serve the AT-SPI window origin,
+  `FocusedWindowBounds` and (for GNOME) the app watcher. What is shared across
+  compositors goes in a package named for the mechanism:
   `internal/adapter/platform/compositorcli` is how both callers ask niri, Sway
   and Hyprland their question.
 
 Use a `*_linux_wayland_<compositor>.go` sub-slot only when a compositor family
 needs a path no other family shares, spelled without the OS token inside
-`internal/adapter/platform/linux/`: `system_wayland_wlroots_*.go`
-(virtual-pointer input) and `system_wayland_kde_*.go` (libei input), with
-`system_wayland_input.go` as the shared routing seam.
+`internal/adapter/platform/linux/`: `system_wayland_wlroots_*.go` and
+`system_wayland_kde_*.go`, with `system_wayland_input.go` as the shared routing
+seam.
 
-**To add a compositor**: add a `LinuxBackend` value and detection
-in `backend_linux.go`, route it in the factory and the relevant dispatch seams,
+**To add a compositor**: add a `LinuxBackend` value and detection in
+`backend_linux.go`, route it in the factory and the relevant dispatch seams,
 and add a new compositor sub-slot *only* if it cannot reuse an existing
 mechanism file.
 
@@ -1435,30 +1129,22 @@ Stable. Prefer `*_windows.go` as the implementation slot and pure Go Win32 /
 COM bindings (via `x/sys/windows` or syscall) over CGO. Do not introduce
 additional Windows backend naming until there is a real reason.
 
-**Elevated windows are out of reach.** User Interface Privilege Isolation
-stops `SendInput` from delivering to a window at a higher integrity level than
-the caller and withholds its keystrokes from the `WH_KEYBOARD_LL` hook, and the
-secure desktop a UAC prompt sits on is out of reach altogether. A Neru started
-from a normal shell, or by the task `neru services install` writes, still gets
-its global hotkeys (`RegisterHotKey` delivers them to Neru's own thread) and
-still moves the cursor (`SetCursorPos` is not subject to UIPI) while an
-elevated app (an installer, an admin terminal, Task Manager run as
-administrator) has focus, but the mode it opens cannot see the keys typed into
-it, which land in the elevated app instead, and every click, scroll and
-injected key is dropped. The remedy is to run Neru elevated too, and it costs
-something: the daemon then holds an administrator token while it watches every
-keystroke and screen element, the service task has to be edited to run with
-highest privileges since `neru services install` does not, and each manual
-launch asks for UAC consent. The secure desktop stays out of reach either way.
+**Elevated windows are out of reach.** User Interface Privilege Isolation stops
+`SendInput` from reaching a window at a higher integrity level and withholds
+its keystrokes from the `WH_KEYBOARD_LL` hook. While an elevated app has focus,
+Neru still gets its global hotkeys and still moves the cursor, but the mode it
+opens cannot see the keys typed into it and every click, scroll and injected
+key is dropped. The remedy is to run Neru elevated too, which costs an
+administrator token on a process that watches every keystroke, a hand-edited
+service task, and a UAC prompt per manual launch. The secure desktop stays out
+of reach either way.
 
 **Smooth cursor animation on Windows** is the Linux animator's shape with
 `SetCursorPos` as the sink
 ([mouse_animator.go](../internal/adapter/platform/windows/mouse_animator.go)):
-off by default, opt in with `smooth_cursor.move_mouse_enabled`, one worker
-goroutine sampling `GetCursorPos` once per request and stepping toward the
-target with the latest target winning. Relative moves extend the pending
-endpoint over `smooth_cursor.relative_movement_duration`, clamped to the active
-screen, and position-dependent actions settle the animation before acting.
+off by default, opt in with `smooth_cursor.move_mouse_enabled`, relative moves
+extend the pending endpoint, and position-dependent actions settle the
+animation before acting.
 
 ## CGO Guidance
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -248,22 +248,13 @@ floor as well as a report — the step fails if nothing executed, or if a test
 skipped because it could not see the display server the job exists to provide,
 because a leg that skips its way to green is worth less than no leg at all.
 
-**Both desktop legs block.** They started advisory, because they were the first
-jobs here to stand up infrastructure of their own — a compositor, a session bus
-and an accessibility bus — and a flake in any of the three would have redded a
-pull request for a reason that had nothing to do with it, on a tier whose
-stability nothing had measured yet. That last clause is what changed: across 40
-runs each on pull requests and `main`, neither leg had a failing step, so the
-flake rate stopped being an unknown and became a number. Job-level
-`continue-on-error` reports a failed job as successful, so that count was taken
-from step conclusions rather than job ones.
-
-It matters that they block. Neru is developed on macOS, where none of the
-behavior these legs exercise can run, so ADR 0013's promises are worth exactly
-as much as the jobs that check them — and an advisory job that nobody has to
-read is not a check. The two legs owe different bars, and that difference is
-about what the tests assert rather than about what a failure means: a suite that
-passes today and starts failing tomorrow is a regression at either bar.
+**Both desktop legs block.** They started advisory while the flake rate of
+the compositor, session bus and accessibility bus they stand up was unmeasured;
+after 40 clean runs each on pull requests and `main` (counted from step
+conclusions, since job-level `continue-on-error` reports a failed job as
+successful) they were made required. Neru is developed on macOS, where none of
+this behavior can run, so these jobs are the only check on ADR 0013's Linux
+promises.
 
 ### What the Xvfb X11 leg covers, and what it does not
 
@@ -305,10 +296,9 @@ What it does not cover:
 - **Anything needing device access**, for the same reasons as the sway leg: no
   `/dev/dri`, no `input` group.
 
-It does deliver a verdict: this leg blocks too, on the same measurement. A lower
-bar is a smaller set of claims, not a weaker consequence for breaking one.
+This leg blocks too, on the same measurement.
 
-**It found a defect on its first run, which is the point.** Because the session
+**It found a defect on its first run.** Because the session
 has a window manager and no client, `internal/adapter/platform`'s capability
 contract — `TestCapabilities_DeclaredStatusMatchesAdapterBehavior` and
 `TestCapabilities_StubsSurfaceNotSupportedNotNil` — runs against a live X11
@@ -398,22 +388,21 @@ test harness is documented in
 processing, mode transitions, config parsing/validation/defaults, and CLI
 argument handling. These run everywhere.
 
-**Integration** — almost all of these are **macOS**: real Accessibility and
-event tap APIs, global hotkey registration, overlay and window management, Unix
+**Integration** — most of these are **macOS**: real Accessibility and event
+tap APIs, global hotkey registration, overlay and window management, Unix
 socket IPC, config file loading and reloading, and service-to-adapter
-coordination. Linux has exactly one so far — the fontconfig font resolver
-(`internal/adapter/platform/linux/font_integration_linux_test.go`, which reads
-what is installed with `fc-list` and skips where fontconfig has nothing to
-report) — and Windows has none, so behavior on both is otherwise pinned by unit
-and contract tests alone. Adding real ones is one of the more valuable
-contributions available.
+coordination. Linux has a handful under `internal/adapter/platform/linux/`
+(fontconfig, X11, screen capture, OCR, notifications) plus the evdev probe,
+the smooth-scroll measurement and `neru services`; Windows has the services
+command, the overlay transition and the UIA tree walk. Everything else on both
+is pinned by unit and contract tests, so adding real ones is one of the more
+valuable contributions available.
 
-No `just` recipe runs the Linux ones: `just test-linux` runs the container
-without the `integration` tag, and `just test-integration` runs on the host.
-Until there is a recipe, run them the way the container recipe does and add the
-tag — `docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=1 neru-linux-ci go
-test -tags=integration ./...` — on an image with fonts and `fc-list` installed
-(`fontconfig fonts-dejavu-core`). CI covers them on `ubuntu-latest`, where
+No `just` recipe runs the Linux ones from a macOS host: `just test-linux` runs
+the container without the `integration` tag, and `just test-integration` runs
+on the host. Run them the way the container recipe does and add the tag —
+`docker run --rm -v "$PWD":/src -w /src -e CGO_ENABLED=1 neru-linux-ci go test
+-tags=integration ./...`. CI covers them on `ubuntu-latest`, where
 `just test-ci` runs the integration suite natively, and again on the two desktop
 legs, which run `just test-desktop` inside a real wlroots session and a real X11
 one — see [What the headless-sway job covers](#what-the-headless-sway-job-covers-and-what-it-does-not)
@@ -453,8 +442,9 @@ log_level = "debug"
 Then follow the log:
 
 ```bash
-tail -f ~/Library/Logs/neru/app.log       # macOS
-tail -f ~/.local/state/neru/log/app.log   # Linux
+tail -f ~/Library/Logs/neru/app.log                # macOS
+tail -f ~/.local/state/neru/log/app.log            # Linux ($XDG_STATE_HOME honoured)
+Get-Content -Wait $env:LOCALAPPDATA\neru\log\app.log  # Windows
 ```
 
 For a step debugger:
@@ -533,13 +523,15 @@ that unwind in reverse on failure.
 
 `app.New` takes functional options ([options.go](../internal/app/options.go)),
 which is how tests substitute doubles for the ports they need — `WithSystemPort`,
-`WithEventTap`, `WithIPCServer`, `WithOverlayPort`, `WithHotkeyService`,
-`WithWatcher`, plus `WithConfig` / `WithConfigPath` / `WithLogger`. An option
-that is not supplied falls back to the real adapter built during initialization.
+`WithAccessibility`, `WithEventTap`, `WithIPCServer`, `WithOverlayPort`,
+`WithHotkeyService`, `WithWatcher`, `WithTextInput`, plus `WithConfig` /
+`WithConfigPath` / `WithLogger` and the config-load carriers `WithWrittenConfig`
+/ `WithConfigWarnings`. An option that is not supplied falls back to the real
+adapter built during initialization.
 
 ```go
 hintService := services.NewHintService(accAdapter, overlayAdapter, systemPort, hintGen, cfg.Hints, logger, visionPort)
-gridService := services.NewGridService(overlayAdapter, systemPort, logger)
+gridService := services.NewGridService(overlayAdapter)
 actionService := services.NewActionService(accAdapter, overlayAdapter, systemPort, logger)
 ```
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -6,7 +6,7 @@ This guide covers installation methods for Neru, with the most complete support 
 [Linux setup](LINUX_SETUP.md) · [Troubleshooting](TROUBLESHOOTING.md)
 
 > [!NOTE]
-> macOS is the primary supported platform. Linux builds are available through the Nix flake (uses release artifacts when available, falls back to source build), and direct source builds. See the [Platform Support section in README.md](../README.md#platform-support) for details.
+> macOS is the primary supported platform; Linux and Windows are Beta. Every method below ships all three except Homebrew, which is macOS only. What works where is in the [Cross-Platform Guide](CROSS_PLATFORM.md#capability-matrix).
 
 ---
 
@@ -135,7 +135,7 @@ Homebrew or Nix-managed install and prints the command to use instead.
 > The homebrew tap is maintained in another repo: [y3owk1n/homebrew-tap](https://github.com/y3owk1n/homebrew-tap)
 > If there's a problem with the tap, please open an issue in that repo or even better, a PR.
 
-Note that you cannot have both `stable` and `nightly` installed at the same time. Uninstall the other one first or it will error out.
+You cannot have both `stable` and `nightly` installed at the same time. Uninstall the other one first or it will error out.
 
 ```bash
 brew tap y3owk1n/tap
@@ -150,8 +150,7 @@ brew install --cask y3owk1n/tap/neru-nightly
 brew upgrade --cask y3owk1n/tap/neru
 
 # Upgrade to latest nightly release
-# Note that you will need to do `--greedy` due to the nature of nightly releases
-# without `--greedy`, it won't upgrade the rolling releases
+# `--greedy` is required: without it brew skips rolling releases
 brew upgrade --cask --greedy y3owk1n/tap/neru-nightly
 
 # Uninstall stable
@@ -596,13 +595,13 @@ nix flake update neru
 ### Patch Go Version
 
 > [!NOTE]
-> This is only required if you're using `nix`, you're using the `neru-source` package and nixpkgs is not on golang `1.26.4` yet.
+> This is only required if you're using `nix`, you're using the `neru-source` package and nixpkgs is not on golang `1.26.5` yet.
 
 ```nix
 package = pkgs.neru-source.overrideAttrs (_: {
   postPatch = ''
      substituteInPlace go.mod \
-       --replace-fail "go 1.26.4" "go 1.25.5"
+       --replace-fail "go 1.26.5" "go 1.25.5"
 
      # Verify it worked
      echo "=== go.mod after patch ==="

--- a/docs/LINUX_DESKTOPS.md
+++ b/docs/LINUX_DESKTOPS.md
@@ -1,10 +1,11 @@
 # Linux Desktop Environments
 
-Per-desktop-environment notes for Neru on Linux: measured protocol support,
-desktop-specific setup, known issues, and how to diagnose them.
+Per-desktop notes for Neru on Linux: what each desktop needs from you, the
+consent prompts it shows, the protocols it was measured to offer, and the
+issues specific to it.
 
-This document is the **empirical, per-desktop** layer. The mechanism behind
-each capability, which protocol or API implements it and why, is in the
+This is the **per-desktop** layer. Which protocol or API implements each
+capability, and why, is in the
 [Capability Matrix](CROSS_PLATFORM.md#capability-matrix). Host preparation
 (dependencies, permissions, build, deploy) is in
 [LINUX_SETUP.md](./LINUX_SETUP.md).
@@ -31,25 +32,12 @@ each capability, which protocol or API implements it and why, is in the
 **Backend:** `wayland-kde`
 **Status:** Supported (Plasma 6 / KWin on Wayland)
 
-### Why KDE differs from wlroots
-
-KWin does **not** implement `zwlr_virtual_pointer_v1`, so Neru cannot use the
-wlroots input path here. It splits the difference: overlays and screen geometry
-go through the shared wlroots client (KWin does implement layer-shell), while
-all pointer and keyboard injection goes through **libei** via
-`org.freedesktop.portal.RemoteDesktop`.
-
-Routing lives in `system_wayland_input.go`. If the compositor advertises
-`zwlr_virtual_pointer_v1` it uses the virtual pointer, otherwise libei. The two
-paths never overlap. Code slots: `platform/linux/system_wayland_kde_*.go`,
-`platform/kwin/`, `accessibility/atspi/kwin_origin.go`.
-
-AT-SPI reports window-relative coordinates, so a KWin script pushes
-focused-window geometry over D-Bus to translate them into global compositor
-space. The same script answers `FocusedWindowBounds`, see
-[window-origin offsets](CROSS_PLATFORM.md#accessibility-and-hints). A
-`kwin --replace` or a Plasma crash takes the script with it, and Neru reinstalls
-it when KWin comes back on the session bus.
+KWin implements layer-shell but not `zwlr_virtual_pointer_v1`, so overlays and
+screen geometry take the shared Wayland client while pointer and keyboard
+injection go through **libei** via `org.freedesktop.portal.RemoteDesktop`.
+Screen capture goes through `org.freedesktop.portal.ScreenCast`. A KWin script
+reports focused-window geometry over D-Bus so AT-SPI's window-relative hint
+coordinates can be placed on screen; Neru reinstalls it when KWin restarts.
 
 ### Protocol support (KWin 6.6.4, measured)
 
@@ -66,33 +54,19 @@ it when KWin comes back on the session bus.
 Re-measure with the one-liner under
 [Checking compositor protocols](#checking-compositor-protocols).
 
-With no screencopy protocol, screen capture on KDE goes through
-`org.freedesktop.portal.ScreenCast` with frames over PipeWire. That is a consent
-gate rather than a protocol Neru can bind, see
-[Screen-sharing consent](#screen-sharing-consent).
-
 ### Setup notes (beyond LINUX_SETUP.md)
 
-1. **RemoteDesktop consent.** The first daemon start on a machine shows a
-   "Remote Control" portal prompt. Approve it once. Neru asks the portal to
-   persist the session and keeps the restore token in
-   `$XDG_STATE_HOME/neru/remote-desktop.token` (`~/.local/state/neru/` by
-   default), readable by you alone. Deleting that file, or revoking the
+1. **RemoteDesktop consent.** The first daemon start shows a "Remote Control"
+   portal prompt. **Check "Enable keyboard"** before allowing, or modified
+   clicks degrade and `neru action feed` is refused. Neru persists the grant
+   with a restore token in `$XDG_STATE_HOME/neru/remote-desktop.token`
+   (`~/.local/state/neru/` by default). Deleting that file, or revoking the
    permission in System Settings, brings the prompt back on the next start.
-2. **Hotkeys.** Neru's own `[hotkeys]` config works on KDE Wayland when the
-   daemon can read `/dev/input`, see
-   [Global hotkeys on Wayland](#global-hotkeys-on-wayland). If you would rather
-   not grant that access, bind the modes in **System Settings > Shortcuts >
-   Custom Shortcuts** instead, using the absolute path so KWin resolves it
-   reliably:
-
-    | Action         | Command                                      |
-    | -------------- | -------------------------------------------- |
-    | Hints          | `/home/<you>/.local/bin/neru hints`          |
-    | Grid           | `/home/<you>/.local/bin/neru grid`           |
-    | Recursive grid | `/home/<you>/.local/bin/neru recursive_grid` |
-    | Scroll         | `/home/<you>/.local/bin/neru scroll`         |
-
+2. **Hotkeys.** Neru's own `[hotkeys]` work when the daemon can read
+   `/dev/input`, see [Global hotkeys on Wayland](#global-hotkeys-on-wayland).
+   Otherwise bind the modes in **System Settings > Shortcuts > Custom
+   Shortcuts** with the absolute path, for example
+   `/home/<you>/.local/bin/neru hints`.
 3. **Portal services.** Input and screen capture both need
    `xdg-desktop-portal` and `xdg-desktop-portal-kde` running in the session.
 
@@ -100,33 +74,20 @@ gate rather than a protocol Neru can bind, see
 
 `hints.strategy = "vision"` or `"contour"` reads the screen through the
 portal's ScreenCast session. This is a second grant, separate from "Remote
-Control", because sharing your screen and driving your pointer are two
-different permissions and KDE asks them separately.
+Control", and it appears the first time a capture-strategy hint activation
+needs a frame, as a source picker. Pick every screen you are willing to have
+read: a region on a screen you did not share fails rather than coming back
+cropped. Neru asks for monitors only, with the pointer left out.
 
-The prompt appears the first time a capture-strategy hint activation needs a
-frame, not at startup, and it is a source picker rather than a yes/no dialog.
-Pick every screen you are willing to have read: a region on a screen you did
-not share fails rather than coming back cropped. Neru asks for monitors only,
-never windows, because only a monitor stream says where on screen its pixels
-are. The pointer is left out of the frames.
-
-Approve it once. The restore token is kept in
-`$XDG_STATE_HOME/neru/screen-cast.token`, readable by you alone, so later
+The restore token is kept in `$XDG_STATE_HOME/neru/screen-cast.token`, so later
 starts restore the grant with no picker. Deleting that file, or revoking the
 permission in **System Settings > Apps & Window Management > Application
 Permissions**, brings the picker back. A capture never raises the dialog by
-itself: a hint refresh that finds no grant fails and says a grant is needed.
-
-The session is established once and reused. The PipeWire connection under it
-is opened per capture and closed with it, so KWin is not streaming your screen
-between the frames Neru reads.
+itself, and the PipeWire connection is opened per capture and closed with it,
+so KWin is not streaming your screen between frames.
 
 ### Known issues
 
-- **Modifier keys and `feed` need a keyboard device from the portal.** The
-  RemoteDesktop grant defaults to pointer-only. Without a keyboard device,
-  modified clicks degrade and `neru action feed` returns `CodeNotSupported`
-  with a message naming the fix below.
 - **Hints coverage** depends on each app exposing an AT-SPI tree. Grid and
   scroll work without AT-SPI.
 
@@ -135,43 +96,25 @@ between the frames Neru reads.
 **"could not establish a libei input session via the RemoteDesktop portal"**
 
 Approve the consent dialog before the connect times out. If denied, revoke and
-re-grant in System Settings (Apps & Window Management / portal permissions),
-and confirm the portal services are running.
+re-grant in System Settings, and confirm the portal services are running. A
+grant revoked while Neru still held its token needs no cleanup: the token is
+dropped on the first refusal and the prompt shown again on that start.
 
-A grant revoked while Neru still held its restore token needs no manual
-cleanup: the stored token is dropped on the first refusal and the prompt is
-shown once more on that same start. To start clean, delete
-`~/.local/state/neru/remote-desktop.token`.
+**"key feeding unavailable: the RemoteDesktop portal session did not grant a keyboard device"**
 
-**"key feeding unavailable on KDE: the RemoteDesktop portal session did not grant a keyboard device"**
+The grant was made without the keyboard. Clear it and start over:
 
-Start from a fresh portal grant:
+- **Plasma 6.5+**: **System Settings > Applications > Remote Desktop**, remove
+  any saved `neru` permission.
+- **Plasma 6.3+ (CLI)**: `flatpak permission-remove kde-authorized remote-desktop ""`
+  clears KDE's portal permission store for host applications, flatpak or not.
 
-- **Plasma 6.5+**: open **System Settings > Applications > Remote Desktop**,
-  find any saved `neru` permission, and remove it.
-- **Plasma 6.3+ (CLI)**: run
+Then restart the daemon and **check "Enable keyboard"** in the prompt.
 
-    ```sh
-    flatpak permission-remove kde-authorized remote-desktop ""
-    ```
-
-    This clears KDE's portal permission store for host applications and works
-    on any Plasma 6.3 or later whether or not you use flatpak packages.
-
-Then restart the daemon, and when the **"Remote Control"** prompt appears from
-`xdg-desktop-portal-kde`, **check "Enable keyboard"** before clicking Allow. The
-startup log confirms with `Wayland input warm-up complete`, or warns when the
-keyboard was not granted.
-
-**Verifying injected input with the KWin Debug Console**
-
-```bash
-qdbus org.kde.KWin /KWin org.kde.KWin.showDebugConsole
-```
-
-The Input Events tab logs every pointer motion, button, and key event with its
-source device. Neru's injected events appear with an "Unknown" input device
-(libei). Real hardware shows a physical device path.
+**Verifying injected input** with the KWin Debug Console
+(`qdbus org.kde.KWin /KWin org.kde.KWin.showDebugConsole`): the Input Events tab
+shows Neru's events with an "Unknown" device (libei), real hardware with a
+device path.
 
 ---
 
@@ -180,32 +123,14 @@ source device. Neru's injected events appear with an "Unknown" input device
 **Backend:** `wayland-cosmic`
 **Status:** Supported (cosmic-comp; pointer input needs xdg-desktop-portal-cosmic 1.7 or later)
 
-COSMIC sits between wlroots and KDE. cosmic-comp implements layer-shell and
-the virtual keyboard, so overlays, screen geometry and sticky modifiers take
-the shared wlroots client unchanged.
-
-Windows are a different story. cosmic-comp has no wlr toplevel manager. It
-names its windows through `ext_foreign_toplevel_list_v1`, and its own
-`zcosmic_toplevel_info_v1` extends each of those handles with the activated
-state and the window's geometry. The shared client tracks that pair in place
-of the wlr manager, and one source then answers the focused app, the app
-watcher, window-relative hint correction and `FocusedWindowBounds`. No
-compositor CLI or scripting bridge is involved, which is more than niri or
-Sway give us.
-
-Input and capture go the KDE way. cosmic-comp implements neither
-`zwlr_virtual_pointer_v1` nor a screencopy protocol, so pointer input goes
-through libei via `org.freedesktop.portal.RemoteDesktop` and screen capture
-through `org.freedesktop.portal.ScreenCast`, with the same one-time consent
-prompts described under [Screen-sharing consent](#screen-sharing-consent).
-Neither is a COSMIC branch in the code. `system_wayland_input.go` asks the
-compositor for the virtual pointer and falls back to libei when it is absent.
-
-The catch is the portal version. `xdg-desktop-portal-cosmic` only gained
-RemoteDesktop in its 1.7 release, and Fedora 44 ships 1.6. On the older
-portal the daemon starts, the overlay draws and keys are captured, but every
-pointer action fails and names the missing portal. Keyboard capture and
-global hotkeys are the evdev proxy, as on every Wayland session.
+COSMIC sits between wlroots and KDE. cosmic-comp implements layer-shell and the
+virtual keyboard, so overlays, screen geometry and sticky modifiers take the
+shared client unchanged. It has no wlr toplevel manager; its
+`ext_foreign_toplevel_list_v1` plus `zcosmic_toplevel_info_v1` answer the
+focused app, the app watcher, hint offsets and `FocusedWindowBounds` from one
+source, with no compositor CLI involved. Pointer input and screen capture go
+the KDE way through the two portals, with the same one-time consent prompts
+described under [Screen-sharing consent](#screen-sharing-consent).
 
 ### Protocol support (cosmic-comp 1.6.0, measured)
 
@@ -220,16 +145,12 @@ global hotkeys are the evdev proxy, as on every Wayland session.
 | `zwlr_foreign_toplevel_manager_v1`    | (wlr toplevel manager)    | **no**      |
 | `zwlr_screencopy_manager_v1`          | Screen capture            | **no**      |
 
-Geometry arrives in each output's own coordinates. Neru adds the output's
-global origin back, so a window on a second monitor lands in the same global
-top-left space every other backend uses. cosmic-comp replays existing windows
-when the daemon connects. Later changes reach it on the compositor's next
-refresh.
-
 ### Known issues
 
-- Fedora's COSMIC spin ships `xdg-desktop-portal-cosmic` 1.6, which has no
-  RemoteDesktop portal. Upgrade it to 1.7 or later for pointer input.
+- **Portal version.** `xdg-desktop-portal-cosmic` gained RemoteDesktop in 1.7,
+  and Fedora 44 ships 1.6. On the older portal the daemon starts, the overlay
+  draws and keys are captured, but every pointer action fails and names the
+  missing portal. Upgrade to 1.7 or later.
 
 ---
 
@@ -238,21 +159,15 @@ refresh.
 **Backend:** `wayland-wlroots`
 **Status:** Supported: Sway, Hyprland, niri, River, Wayfire, labwc
 
-Detection is by name for those six. Two more routes land here. A compositor
-that tags `XDG_CURRENT_DESKTOP` with `:wlroots`, the convention
-xdg-desktop-portal-wlr keys on and labwc's default, and a compositor that
-leaves the variable unset. That covers dwl, cage, SwayFX, scroll and most
-small wlroots compositors. From there the only question is whether the
-compositor advertises the protocols below, and
-[Checking compositor protocols](#checking-compositor-protocols) answers it in
-one line.
+Detection is by name for those six, plus any compositor that tags
+`XDG_CURRENT_DESKTOP` with `:wlroots` or leaves it unset, which covers dwl,
+cage, SwayFX, scroll and most small wlroots compositors. From there the only
+question is whether the compositor advertises the protocols
+[Checking compositor protocols](#checking-compositor-protocols) lists.
 
-This is the reference Wayland path: `zwlr_layer_shell_v1` overlays with an
-empty `input_region` for click-through, `zwlr_virtual_pointer_v1` for pointer
+This is the reference Wayland path: layer-shell overlays, `zwlr_virtual_pointer_v1`
 input, `zwp_virtual_keyboard_v1` for sticky modifiers, `zwlr_screencopy_manager_v1`
-for screen capture, and `/dev/uinput` for scrolling and the keyboard proxy. The
-full per-capability breakdown is in the
-[Capability Matrix](CROSS_PLATFORM.md#capability-matrix).
+for capture, and `/dev/uinput` for scrolling and the keyboard proxy.
 
 Two behaviors are specific enough to note here:
 
@@ -260,28 +175,12 @@ Two behaviors are specific enough to note here:
   client-side cache and establishes a known position at startup with a
   layer-shell surface plus a virtual-pointer wiggle. On Hyprland it reads
   `hyprctl` instead.
-- **Per-compositor window origins.** niri, Sway, and Hyprland each expose
-  focused-window geometry differently (`niri msg`, `swaymsg -t get_tree`,
-  `hyprctl -j activewindow`). River, Wayfire and labwc expose none, so hints
-  there stay window-relative. On niri, **tiled** windows, including a maximized column,
-  expose no on-screen position
+- **Window origins.** niri, Sway and Hyprland expose focused-window geometry
+  through their CLIs; River, Wayfire and labwc expose none, so hints there stay
+  window-relative. On niri, **tiled** windows expose no on-screen position
   ([niri#2381](https://github.com/niri-wm/niri/issues/2381)), so hints are
   misaligned there. Details in
   [CROSS_PLATFORM.md](CROSS_PLATFORM.md#accessibility-and-hints).
-
-Code slots: `platform/linux/system_wayland_wlroots_*.go` and the shared wlroots
-C client.
-
-### Testing tips
-
-- **Multi-monitor cursor discovery.** Verify the initial cursor position on
-  asymmetric layouts after daemon start.
-- **Modified keys.** Exercise `Shift`, `Ctrl`, and symbols like `+` / `,` under
-  rapid modifier taps.
-- **Click-through.** In recursive grid, a synthetic click should reach the app
-  beneath the overlay.
-- **Scroll.** Scroll mode should feel smooth, with no compositor event-queue
-  lag.
 
 ### Known issues
 
@@ -292,10 +191,9 @@ C client.
   virtual pointer, which Chromium and Electron apps on Hyprland ignore. Both
   are install-time steps in
   [LINUX_SETUP.md](./LINUX_SETUP.md#install-time-environment-adjustments).
-- **Modified scroll on Hyprland** goes out on the uinput wheel with the
-  modifier held on the virtual keyboard, in whole notches, because a
-  virtual-pointer scroll under a virtual-keyboard modifier produces no event
-  there ([#1474](https://github.com/y3owk1n/neru/pull/1474)).
+- **Modified scroll on Hyprland** goes out on the uinput wheel in whole
+  notches, because a virtual-pointer scroll under a virtual-keyboard modifier
+  produces no event there ([#1474](https://github.com/y3owk1n/neru/pull/1474)).
 
 ---
 
@@ -320,67 +218,34 @@ notches. Build dependencies and systemd deployment are in
 (GNOME Shell 50 / Mutter, measured)
 
 Mutter implements none of the wlr family beyond `zxdg_output_manager_v1`, so
-GNOME borrows more mechanisms from other desktops than any of them, and
-carries one of its own:
+GNOME borrows: pointer input and screen capture take the portal path with the
+same "Remote Control" and [screen-sharing](#screen-sharing-consent) consents
+as KDE (GNOME's portal grants the keyboard with the pointer, so `feed` works
+from the first grant); keyboard capture and global hotkeys are the evdev proxy
+with no compositor fallback; and **the overlay is drawn on Xwayland**, because
+Mutter stacks an override-redirect X window above every toplevel without
+animating or focusing it, where a fullscreen `xdg_toplevel` gets both. The
+daemon refuses to start on a GNOME session with no `DISPLAY`, naming Xwayland.
 
-- **Screens** come off xdg-output through the shared wlroots client, as on
-  every other Wayland desktop.
-- **Pointer input** goes through libei via `org.freedesktop.portal.RemoteDesktop`,
-  the KDE and COSMIC path, with the same one-time "Remote Control" consent and
-  stored restore token described under
-  [KDE setup notes](#setup-notes-beyond-linux_setupmd). GNOME's portal grants
-  the keyboard device together with the pointer, so modified clicks and
-  `neru action feed` work from the first grant.
-- **Screen capture** is the portal's ScreenCast stream, with the
-  [screen-sharing consent](#screen-sharing-consent) picker on the first
-  capture-strategy hint refresh.
-- **Keyboard capture and global hotkeys** are the evdev proxy, as on every
-  Wayland session, and there is no compositor fallback. Without `/dev/input`
-  access, bind the modes in **Settings > Keyboard > Custom Shortcuts** and
-  expect no keyboard capture inside a mode.
-- **The overlay is drawn on Xwayland.** Mutter has no layer shell. A
-  fullscreen `xdg_toplevel` was the obvious substitute and I measured it. It
-  is the wrong shape for an overlay, because GNOME Shell animates its map and
-  unmap and gives it keyboard focus. Mutter stacks an override-redirect X
-  window with an empty input shape above every toplevel, never animates or
-  focuses it, and passes clicks through it, so the X11 overlay serves GNOME
-  unchanged. The daemon refuses to start on a GNOME session with no
-  `DISPLAY`, naming Xwayland.
-- **Cursor position** uses the same trick. Neru maps a transparent
-  override-redirect window that accepts input, the compositor sends the
-  pointer's entry with global coordinates, and Neru destroys the window
-  again, all inside a frame. Mutter keeps the X root in the logical layout,
-  so those coordinates are the ones every other subsystem uses.
-- **The focused window comes from a GNOME Shell extension.** Mutter tells a
-  client neither which window is focused nor where it is, and the shell's own
-  `org.gnome.Shell.Introspect` answers only the portals. Neru ships a small
-  extension, `neru@y3owk1n.github.io`, that owns `org.neru.Shell` on the
-  session bus and reports the focused window's app id (Mutter's `WM_CLASS`,
-  which is the Wayland `app_id` for native clients), title and frame, on
-  request and on every change. It is the same fact three readers share, as
-  the KWin script is on KDE: per-app config and the app watcher key on the
-  app id, hints in native Wayland apps are offset by the frame's origin, and
-  `FocusedWindowBounds` reports the frame. Code:
-  `internal/adapter/platform/gnomeshell`, `atspi/gnome_origin.go`.
+**The focused window comes from a GNOME Shell extension.** Mutter tells a
+client neither which window is focused nor where it is, so Neru ships
+`neru@y3owk1n.github.io`, which owns `org.neru.Shell` on the session bus and
+reports the focused window's app id, title and frame on request and on every
+change. Per-app config, hints in native Wayland apps and `FocusedWindowBounds`
+all read it. It reads `global.display.focus_window` and nothing else, and
+neither logs nor stores anything.
 
 ### The extension
 
-The daemon installs the extension itself. On a GNOME session where
-`org.neru.Shell` is not on the bus, it writes the two files into
-`$XDG_DATA_HOME/gnome-shell/extensions/neru@y3owk1n.github.io/`
-(`~/.local/share` by default), adds the UUID to the shell's
-`enabled-extensions` setting, and warns once with what it did. GNOME Shell
-loads a new extension only at login, so **log out and back in** after the
-first daemon start on a machine. Until then every mode works, but per-app
-config does not apply and hints in native Wayland apps stay window-relative;
-`neru doctor` reports `app_watcher` as a stub with the same instruction. The
-files are rewritten only when a new Neru ships a changed extension, and a
-reinstall never re-enables one you disabled.
-
-The extension does nothing but answer that one question. It reads
-`global.display.focus_window`, watches it for moves, resizes and title
-changes, and emits `FocusedWindowChanged`; it neither logs nor stores
-anything.
+The daemon installs it on first start: it writes the two files into
+`$XDG_DATA_HOME/gnome-shell/extensions/neru@y3owk1n.github.io/`, adds the UUID
+to `enabled-extensions`, and warns once with what it did. GNOME Shell loads a
+new extension only at login, so **log out and back in** after the first daemon
+start. Until then every mode works, but per-app config does not apply and
+hints in native Wayland apps stay window-relative; `neru doctor` reports
+`app_watcher` as a stub with the same instruction. The files are rewritten
+only when a new Neru ships a changed extension, and a reinstall never
+re-enables one you disabled.
 
 ### Protocol support (Mutter 50.4, measured)
 
@@ -396,19 +261,16 @@ anything.
 
 ### Known issues
 
-- **A fresh install needs one re-login** before the extension serves, see
-  above. `neru doctor` says so until it does.
-- **HiDPI needs Mutter's default Xwayland scaling.** The overlay draws in the
-  X root's coordinate space, which Mutter keeps equal to the logical layout
-  by default, and Mutter then upscales the overlay with every other X client
-  on a scaled monitor. With the `xwayland-native-scaling` experimental feature
-  on, the root is in physical pixels and the overlay lands at the wrong place
-  on scaled monitors. The daemon warns at startup when Xft.dpi says so.
+- **A fresh install needs one re-login** before the extension serves.
+  `neru doctor` says so until it does.
+- **HiDPI needs Mutter's default Xwayland scaling.** With the
+  `xwayland-native-scaling` experimental feature on, the X root is in physical
+  pixels and the overlay lands at the wrong place on scaled monitors. The
+  daemon warns at startup when `Xft.dpi` says so.
 - **Budgie** identifies itself as GNOME and takes this backend untested; its
-  shell is not GNOME Shell, so the extension has nowhere to load. Cinnamon
-  (Muffin) and Pantheon (Gala) are Mutter-based too but resolve to
-  `wayland-other` and are refused. Someone has to run the protocol check
-  below on each before it can be admitted.
+  shell is not GNOME Shell, so the extension has nowhere to load. Cinnamon and
+  Pantheon are Mutter-based too but resolve to `wayland-other` and are refused
+  until someone runs the protocol check below on them.
 
 ---
 
@@ -421,39 +283,28 @@ offers two paths and prefers the first:
 
 1. **Neru's own `[hotkeys]` config**, through the evdev keyboard proxy. Neru
    holds the keyboards and re-emits every key through a uinput keyboard of its
-   own, so a matched chord is consumed before the focused application sees it
-   and a mode captures keys the instant it opens. Without a writable
-   `/dev/uinput` the proxy reads passively instead: the chord still matches,
-   but the application receives it too.
+   own, so a matched chord is consumed before the focused application sees it.
+   Without a writable `/dev/uinput` the proxy reads passively: the chord still
+   matches, but the application receives it too.
 2. **Compositor keybindings.** Bind `neru hints`, `neru grid`, and friends in
    your compositor config or System Settings. Always available, needs no
    permissions, and the right choice if you would rather not grant `/dev/input`
    access.
 
-Path 1 has two requirements:
+Path 1 needs **read access to `/dev/input`** (the `input` group, then re-login,
+see [LINUX_SETUP.md](./LINUX_SETUP.md#wayland-keyboard-capture-permissions))
+and **a CGO build**, which the official Linux builds are. On startup the daemon
+logs `Wayland global hotkeys enabled via evdev; config keybindings are active`
+on success, or a warning naming both the `input` group and the compositor
+fallback.
 
-- **Read access to `/dev/input`.** Add your user to the `input` group and
-  re-login (see
-  [LINUX_SETUP.md](./LINUX_SETUP.md#wayland-keyboard-capture-permissions)), or
-  grant narrower access via udev/ACL.
-- **A CGO build.** evdev support compiles out when `CGO_ENABLED=0`, leaving a
-  stub that reports `CodeNotSupported`. Official Linux builds enable CGO.
-
-On startup the daemon logs which path it took: `Wayland global hotkeys enabled
-via evdev; config keybindings are active` on success, or a warning naming both
-the `input` group and the compositor-binding fallback on failure. The hotkey
-manager health-check re-initializes the listener if it dies or ends up with
-zero devices.
-
-Bindings keep working from inside a mode: the proxy hands every press to the
-mode session while one is open, and the mode handler resolves the global table
-itself. A chord bound in the *compositor* cannot fire while a mode is open,
-because the compositor is not reading the keyboard then.
-
-How the proxy shares one reader between hotkeys and the in-mode event tap:
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md#keyboard-capture-and-hotkeys). Why it
-holds the keyboards at all:
-[ADR 0014](adr/0014-the-wayland-keyboard-is-a-proxy.md).
+Bindings keep working from inside a mode, because the proxy hands every press
+to the mode session and the mode handler resolves the global table itself. A
+chord bound in the *compositor* cannot fire while a mode is open, since the
+compositor is not reading the keyboard then. Why the proxy holds the keyboards
+at all: [ADR 0014](adr/0014-the-wayland-keyboard-is-a-proxy.md); how it shares
+one reader with the in-mode tap:
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#keyboard-capture-and-hotkeys).
 
 ---
 
@@ -465,18 +316,11 @@ Run inside the graphical session (`WAYLAND_DISPLAY` set):
 wayland-info | grep -E 'zwlr_layer_shell|zwlr_virtual_pointer|zwp_virtual_keyboard|zwlr_screencopy|fake_input|xdg_output'
 ```
 
-Neru's wlroots input path needs **both** `zwlr_layer_shell_v1` and
-`zwlr_virtual_pointer_v1`. If the pointer protocol is missing, the compositor
-needs a desktop-specific input path. KDE, COSMIC and GNOME use libei. If the
-layer shell is missing too, the overlay needs one as well, and GNOME draws it
-on Xwayland.
-
-When evaluating a new desktop: if both protocols are present the shared
-wlroots path applies as-is, and the work is adding the compositor to backend
-detection plus a focused-window geometry source. A compositor with layer-shell
-but no virtual pointer can still take the libei path if its portal implements
-RemoteDesktop, as KDE and COSMIC do. The
-daemon refuses to start on a compositor it does not recognize, as
-`wayland-other`. Plan a mechanism-specific backend file rather than a whole
-per-DE stack, see
+Neru's wlroots path needs **both** `zwlr_layer_shell_v1` and
+`zwlr_virtual_pointer_v1`. A compositor with layer-shell but no virtual pointer
+can still take the libei path if its portal implements RemoteDesktop, as KDE
+and COSMIC do; one with neither needs its overlay drawn on Xwayland, as GNOME
+does. The daemon refuses to start on a compositor it does not recognize, as
+`wayland-other`. Adding one is a backend-detection entry, a focused-window
+geometry source, and at most a mechanism-specific file, never a per-DE stack:
 [organize by mechanism, not by desktop](CROSS_PLATFORM.md#organize-by-mechanism-not-by-desktop).

--- a/docs/LINUX_SETUP.md
+++ b/docs/LINUX_SETUP.md
@@ -245,7 +245,8 @@ sudo apt-get install -y \
   libx11-dev \
   libxtst-dev \
   libxrandr-dev \
-  libxinerama-dev \
+  libxrender-dev \
+  libxext-dev \
   libxfixes-dev \
   libxkbcommon-dev \
   libei-dev \
@@ -267,7 +268,8 @@ sudo dnf install -y \
   libX11-devel \
   libXtst-devel \
   libXrandr-devel \
-  libXinerama-devel \
+  libXrender-devel \
+  libXext-devel \
   libXfixes-devel \
   libxkbcommon-devel \
   libei-devel \
@@ -288,7 +290,8 @@ sudo pacman -S \
   libx11 \
   libxtst \
   libxrandr \
-  libxinerama \
+  libxrender \
+  libxext \
   libxfixes \
   libxkbcommon \
   libei \
@@ -307,7 +310,7 @@ leaves every other package uninstalled too.
 Release binaries need only the runtime halves. On Fedora that is `tesseract-libs`
 (the `tesseract` package is the CLI alone), `tesseract-langpack-eng`, `libei`,
 `pipewire-libs`, `cairo`, `libxkbcommon` and the `libX11`, `libXtst`, `libXrandr`,
-`libXinerama` and `libXfixes` packages. The `-devel` packages above pull all of
+`libXrender`, `libXext` and `libXfixes` packages. The `-devel` packages above pull all of
 them in.
 
 `fontconfig` is required at build time. DejaVu fonts are the defaults when
@@ -538,10 +541,10 @@ backend resolved to `wayland-other` and the daemon refused to start. Check the
 variable, and see [Checking compositor protocols](./LINUX_DESKTOPS.md#checking-compositor-protocols)
 before trying to add the compositor.
 
-### "KWin does not implement zwlr_virtual_pointer_v1"
+### "could not establish a libei input session via the RemoteDesktop portal"
 
-Expected on KDE, where input routes through libei and the message accompanies
-a failed portal session. Approve the "Remote Control" prompt, see
+KDE, COSMIC and GNOME route pointer input through the portal. Approve the
+"Remote Control" prompt, see
 [KDE troubleshooting](./LINUX_DESKTOPS.md#kde-plasma-wayland).
 
 ### Overlay or hints wrong size after display change

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -66,7 +66,7 @@ tail -20 ~/Library/Logs/neru/app.log
 
 **Common issues:**
 
-- ❌ **"Failed to connect to Neru daemon"** → Daemon not running, run `neru launch`
+- ❌ **CLI says it cannot reach the daemon** → Daemon not running, run `neru launch`
 - ❌ **"Permission denied"** → Grant accessibility permissions
 - ❌ **No hints appear** → Check app exclusions, try different app
 
@@ -105,8 +105,8 @@ Allow local scripts for your user account, then open a new window:
 Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 ```
 
-Newer installer versions check the policy first and offer this before writing
-the profile. To drop the completion instead, delete the two lines under
+The installer checks the policy first and offers this before writing the
+profile. To drop the completion instead, delete the two lines under
 `# neru shell completion (managed by install.ps1)` in the profile.
 
 **Linux: "error while loading shared libraries: libtesseract.so.5"** (Fedora)
@@ -173,15 +173,6 @@ Alternatively, you can change the shortcut that you use to activate `hints` to c
 
 A tiling window manager with focus-follows-mouse avoids this at the source.
 
-### Misaligned hints/grids
-
-**Rare issue.** Enable debug logging and check logs:
-
-```toml
-[logging]
-log_level = "debug"
-```
-
 ### Hints not showing in browsers (Chrome, Firefox, Safari, Brave, Edge, Electron apps)
 
 **Browser engine detection is fully automatic.** Neru identifies the rendering engine (Chromium, Firefox, WebKit, Electron) by inspecting the app bundle — no manual configuration needed.
@@ -237,17 +228,12 @@ clickable_roles = [
 ]
 ```
 
-### Menubar/Dock hints missing
-
-```toml
-[hints]
-include_menubar_hints = true
-include_dock_hints = true
-```
-
 ### Hints or grids appear but are misaligned
 
-Hints or grids should always be accurate. This is rare.\*\*
+Hints and grids should always be accurate, so this is a bug worth reporting.
+On Linux Wayland, hints in native apps depend on a window-origin source for
+your compositor; see the per-compositor table in
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#accessibility-and-hints).
 
 **Solution:**
 
@@ -267,7 +253,7 @@ tail -f ~/Library/Logs/neru/app.log
 # - Screenshot
 ```
 
-### No hints in menubar/Dock
+### No hints in menubar/Dock (macOS)
 
 **Disabled in config or not enabled.**
 
@@ -346,8 +332,8 @@ osascript -e 'id of app "AppName"'
 
 ```toml
 [hotkeys]
-"Primary+Shift+Space" = ""  # Disable default
-"Ctrl+Alt+Space" = "hints"  # Use different combo
+"Primary+Shift+Space" = "__disabled__"  # Remove the default binding
+"Ctrl+Alt+Space" = "hints"              # Use a different combo
 ```
 
 **Option 2: Disable system shortcut**
@@ -377,7 +363,7 @@ Then disable Neru hotkeys:
 
 ### Hints appear slowly
 
-Possible causes:\*\*
+**Possible causes:**
 
 1. Too many depth levels in the accessibility tree of current activation
 2. Debug logging enabled
@@ -397,8 +383,6 @@ top -o cpu
 
 ### High CPU usage
 
-**Neru should not use too much CPU.**
-
 **Solution:**
 
 ```bash
@@ -416,7 +400,7 @@ pkill neru && neru launch
 
 ## Daemon Issues
 
-### "Failed to connect to Neru daemon"
+### CLI cannot reach the daemon
 
 **Daemon not running.**
 
@@ -508,8 +492,6 @@ tail -f ~/Library/Logs/neru/app.log
 ```
 
 ### Daemon won't quit
-
-**Force termination needed.**
 
 **Solution:**
 
@@ -604,12 +586,12 @@ If you're still experiencing issues:
         ```
 
 3. **Layout changes at runtime not picked up:**
-    - Neru now automatically re-registers global hotkeys when the keyboard layout changes (e.g., switching from US to Dvorak while Neru is running)
+    - Neru re-registers global hotkeys when the keyboard layout changes (e.g., switching from US to Dvorak while Neru is running)
     - If hotkeys don't work after a layout switch, try toggling Neru off and on, or restart the daemon with `pkill neru && neru launch`
 
 ### Input methods not working (CJK IME)
 
-Neru now supports CJK input methods (Pinyin, Wubi, etc.). When using an input method:
+Neru supports CJK input methods (Pinyin, Wubi, etc.). When using an input method:
 
 - Hints work correctly
 - Key presses are translated through your physical keyboard layout
@@ -626,41 +608,38 @@ If input methods still don't work:
 
 ### Config changes not taking effect
 
-**Daemon needs restart to reload config.**
+**The daemon does not watch the file.** Apply an edit with `neru config reload`.
+If the reload was refused, the whole file is rejected and the daemon keeps the
+previous configuration, so validate first.
 
 **Solution:**
 
 ```bash
-# Restart daemon
-pkill neru && neru launch
+neru config validate     # names the offending key
+neru config reload
 
-# Verify config location
-neru status
-# Check "Config:" line
+# Confirm which file the daemon is reading
+neru status --json | jq -r .config
 ```
+
+Values set with `neru config set` live in `config.override.toml` beside your
+config and win over it; `neru config reset <key>` removes one. See
+[Config Layering](CONFIGURATION.md#config-layering).
 
 ### "Failed to parse config"
 
-**TOML syntax error.**
+**TOML syntax error, or a value a validator refuses.**
 
 **Solution:**
 
 ```bash
-# Check logs
-cat ~/Library/Logs/neru/app.log | grep ERROR
-
-# Common issues:
-# - Missing quotes around keys/values
-# - Incorrect section headers
-# - Invalid TOML syntax
-
-# Validate TOML syntax online:
-# https://www.toml-lint.com/
-
-# Or use default config as reference:
-curl -o /tmp/default.toml \
-  https://raw.githubusercontent.com/y3owk1n/neru/main/configs/default-config.toml
+neru config validate     # prints the line or key and why it was refused
 ```
+
+Common causes: missing quotes around a key that contains `+`, a section header
+typo, a hotkey bound to an empty string (use `__disabled__` to remove a
+binding). Compare against
+[default-config.toml](https://github.com/y3owk1n/neru/blob/main/configs/default-config.toml).
 
 ### Colors not working
 


### PR DESCRIPTION
## Description

This PR brings the ten reference docs back in line with the code. Every concrete claim in them was checked against the tree: command and flag lists against the CLI, every config key and default against the loaded defaults, file paths and symbol names against the source, quoted log messages against what the daemon prints, and capability status against the matrix.

What a reader gets that was wrong before: the README no longer carries a second copy of the capability table (it had drifted on Windows monitor select and OCR); the CLI reference says monitor select and the services command work on Windows and lists the hint-search action; the configuration reference shows the full default hotkey tables for every mode and the right monitor-select border default; the troubleshooting guide tells you to hot-reload instead of restart, to run the validate command instead of an online linter, and shows the sentinel that actually disables a binding (the old example was refused by the loader). The architecture and development guides describe the current overlay handoff, mode list, functional options and test coverage.

Two long pages were also trimmed in place with all headings, tables and anchors kept: the cross-platform guide from 1625 to 1311 lines and the Linux desktops page from 482 to 326, by cutting mechanism narration that duplicates the matrix or the code and leaving a pointer. No status claim changed in that trimming.

## Related Issues

None.

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [x] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no code changed
- [x] `just ci` passes — docs-only fast path instead: `just fmt-check && just lint` green, plus `go test ./internal/architecture/` (doc-link integrity and guide citations) green
- [x] Tests added/updated for new or changed functionality — N/A, docs only
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The Linux build-dependency lists in the setup guide now name Xrender and Xext, which the X11 overlay links, instead of Xinerama, which nothing in the tree uses. The matching change to the CI workflows, the justfile container images, the Nix package and devbox is a separate PR so this one stays docs-only.

The generated sections (the mode-flag table in the CLI reference and the per-word platform table in the cross-platform guide) were regenerated and are byte-identical.
