### PR TITLE
build(linux): declare the libraries the cgo build actually links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,10 @@ jobs:
             # wrong for fork PRs. On push events it checks out the pushed ref.
             - uses: actions/checkout@v7
 
-            # Install Linux system dependencies (Wayland, X11, Cairo, etc.)
-            # Devbox doesn't pull *-dev outputs (https://github.com/jetify-com/devbox/issues/2761)
+            # Install Linux system dependencies (Wayland, X11, Cairo, etc.) via apt
+            # so the runner exercises the distro packages users build against;
+            # devbox is only used on macOS here. libxtst-dev depends on libxi-dev,
+            # which XTest.h includes, so Xi is not listed explicitly.
             - name: Install Linux system dependencies
               if: runner.os == 'Linux'
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,11 @@ jobs:
                     libx11-dev \
                     libxtst-dev \
                     libxrandr-dev \
-                    libxinerama-dev \
+                    libxrender-dev \
+                    libxext-dev \
                     libxfixes-dev \
                     libxkbcommon-dev \
+                    libfontconfig-dev \
                     wayland-protocols \
                     libei-dev \
                     liboeffis-dev \

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -180,9 +180,11 @@ jobs:
                     libx11-dev \
                     libxtst-dev \
                     libxrandr-dev \
-                    libxinerama-dev \
+                    libxrender-dev \
+                    libxext-dev \
                     libxfixes-dev \
                     libxkbcommon-dev \
+                    libfontconfig-dev \
                     wayland-protocols \
                     libei-dev \
                     liboeffis-dev \
@@ -244,9 +246,11 @@ jobs:
                     libx11-dev \
                     libxtst-dev \
                     libxrandr-dev \
-                    libxinerama-dev \
+                    libxrender-dev \
+                    libxext-dev \
                     libxfixes-dev \
                     libxkbcommon-dev \
+                    libfontconfig-dev \
                     wayland-protocols \
                     libei-dev \
                     liboeffis-dev \

--- a/devbox.json
+++ b/devbox.json
@@ -19,38 +19,51 @@
 		},
 		"cairo": {
 			"version": "1.18.4",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"wayland": {
 			"version": "1.22.0",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"xorg.libX11": {
 			"version": "1.8.12",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"xorg.libXrender": {
 			"version": "0.9.12",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"xorg.libXext": {
 			"version": "1.3.6",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"xorg.libXtst": {
 			"version": "1.2.5",
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
+		"xorg.libXi": {
+			"version": "1.8.2",
+			"outputs": ["out", "dev"],
+			"platforms": ["x86_64-linux", "aarch64-linux"]
+		},
 		"xorg.libXrandr": {
 			"version": "1.5.4",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"xorg.libXfixes": {
 			"version": "6.0.1",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"libxkbcommon": {
 			"version": "1.13.1",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"wayland-protocols": {
@@ -59,6 +72,7 @@
 		},
 		"fontconfig": {
 			"version": "2.18.2",
+			"outputs": ["out", "dev"],
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"libei": {
@@ -77,7 +91,7 @@
 	},
 	"shell": {
 		"init_hook": [
-			"if [[ \"$(uname)\" == \"Linux\" ]]; then export PKG_CONFIG_PATH_FOR_TARGET=\"$(find /nix/store -maxdepth 5 -type d -name pkgconfig 2>/dev/null | tr '\\n' ':')\" && export CGO_CFLAGS=\"-I$(pkg-config --variable=includedir cairo) $CGO_CFLAGS\"; fi",
+			"if [[ \"$(uname)\" == \"Linux\" ]]; then export PKG_CONFIG_PATH=\"$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}\"; fi",
 			"if [[ \"$(uname)\" == \"Linux\" && -z \"${TESSDATA_PREFIX:-}\" ]]; then export TESSDATA_PREFIX=\"$(pkg-config --variable=prefix tesseract 2>/dev/null)/share/tessdata\"; fi"
 		]
 	}

--- a/devbox.json
+++ b/devbox.json
@@ -45,10 +45,6 @@
 			"version": "1.5.4",
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
-		"xorg.libXinerama": {
-			"version": "1.1.5",
-			"platforms": ["x86_64-linux", "aarch64-linux"]
-		},
 		"xorg.libXfixes": {
 			"version": "6.0.1",
 			"platforms": ["x86_64-linux", "aarch64-linux"]
@@ -61,8 +57,8 @@
 			"version": "1.33",
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
-		"xorg.libXi": {
-			"version": "1.8.2",
+		"fontconfig": {
+			"version": "2.18.2",
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		},
 		"libei": {

--- a/devbox.json
+++ b/devbox.json
@@ -77,7 +77,7 @@
 	},
 	"shell": {
 		"init_hook": [
-			"if [[ \"$(uname)\" == \"Linux\" ]]; then export PKG_CONFIG_PATH_FOR_TARGET=\"$(find /nix/store -maxdepth 5 -type d -name pkgconfig 2>/dev/null | tr '\\n' ':')\" && export CGO_CFLAGS=\"-I$(pkg-config --variable=includedir cairo) $(pkg-config --cflags xi) $CGO_CFLAGS\"; fi",
+			"if [[ \"$(uname)\" == \"Linux\" ]]; then export PKG_CONFIG_PATH_FOR_TARGET=\"$(find /nix/store -maxdepth 5 -type d -name pkgconfig 2>/dev/null | tr '\\n' ':')\" && export CGO_CFLAGS=\"-I$(pkg-config --variable=includedir cairo) $CGO_CFLAGS\"; fi",
 			"if [[ \"$(uname)\" == \"Linux\" && -z \"${TESSDATA_PREFIX:-}\" ]]; then export TESSDATA_PREFIX=\"$(pkg-config --variable=prefix tesseract 2>/dev/null)/share/tessdata\"; fi"
 		]
 	}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1444,6 +1444,106 @@
         }
       }
     },
+    "xorg.libXi@1.8.2": {
+      "last_modified": "2025-10-09T02:37:25Z",
+      "resolved": "github:NixOS/nixpkgs/2dad7af78a183b6c486702c18af8a9544f298377#xorg.libXi",
+      "source": "devbox-search",
+      "version": "1.8.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i9kf1vypnih3hsksjvlw608rym41drn4-libXi-1.8.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/lgm5b4ib7ms20hc410cn56h8k31cv6r5-libXi-1.8.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/vz2145aibxnz34p1rn0k5anf7ymh147h-libXi-1.8.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/99qbk55q3h4dv5d9x3sm26jzv7b4vh4p-libXi-1.8.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/i9kf1vypnih3hsksjvlw608rym41drn4-libXi-1.8.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l5c4w2ayd9ffm6z3j5gb2vqkwsjlzl69-libXi-1.8.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/0f5633zfq9irz04xh86msywb3dw6h510-libXi-1.8.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/g9qgx9w8wj3jhvr80cyzb3szcg8yc3l5-libXi-1.8.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/l13z2729z069a2ywn61lldkqm47r1pjb-libXi-1.8.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/l5c4w2ayd9ffm6z3j5gb2vqkwsjlzl69-libXi-1.8.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/b6hak91sbwj0cngywrb236f179r38y3c-libXi-1.8.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/wkjrj121g3s9g4rvcl411k195xy31w2m-libXi-1.8.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/8wzbhcgb1ghag4b883wpn4gzdjq0riii-libXi-1.8.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ndwrw0pqnwsmw1q2sspddjx0i1scwnl2-libXi-1.8.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/b6hak91sbwj0cngywrb236f179r38y3c-libXi-1.8.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6nk1smsrxzsjcppwljylwa9swfiavfy1-libXi-1.8.2",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/iagca52p1cddxn9n4akag980gp94fp2c-libXi-1.8.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/lnrprzw8rwznjkdc2jmgcys90rkgsbcn-libXi-1.8.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/qcb8dnccp2cna09b4ryzyfp0fs1g7hv3-libXi-1.8.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/6nk1smsrxzsjcppwljylwa9swfiavfy1-libXi-1.8.2"
+        }
+      }
+    },
     "xorg.libXrandr@1.5.4": {
       "last_modified": "2025-07-28T17:09:23Z",
       "resolved": "github:NixOS/nixpkgs/648f70160c03151bc2121d179291337ad6bc564b#xorg.libXrandr",

--- a/devbox.lock
+++ b/devbox.lock
@@ -137,6 +137,80 @@
         }
       }
     },
+    "fontconfig@2.18.2": {
+      "last_modified": "2026-08-27T23:47:58Z",
+      "resolved": "github:NixOS/nixpkgs/7d1a7c21a4c00ea653fc7ed5c083d261340f185f#fontconfig",
+      "source": "devbox-search",
+      "version": "2.18.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/nqysidl8dzq30nxnqfj5h4xjgxi333m3-fontconfig-2.18.2-bin",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/sdb502rn5gv1qf1bvwznmp5zp9jn2lvs-fontconfig-2.18.2-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/0myrip6l3dyj4vjhr38i590mns08xvzc-fontconfig-2.18.2-lib"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/k5d9w5hd7n7sn85sz2b0hzky3hxb1dc0-fontconfig-2.18.2"
+            }
+          ],
+          "store_path": "/nix/store/nqysidl8dzq30nxnqfj5h4xjgxi333m3-fontconfig-2.18.2-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/vsz5rzfzvjlwzaiv48brly2n4jwp7gjw-fontconfig-2.18.2-bin",
+              "default": true
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/pfw3851d34mxqx7ysz7lv7lx17r78jf5-fontconfig-2.18.2-lib"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/69w8pn766sbaj956mmn5h4ggn9s50az4-fontconfig-2.18.2"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/cp330nldfrj6z2vp6cyqqddghbwsb60j-fontconfig-2.18.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/vsz5rzfzvjlwzaiv48brly2n4jwp7gjw-fontconfig-2.18.2-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/122fcxcqy3ay3jkm3fa2bav0vb8mgdjy-fontconfig-2.18.2-bin",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/vwlb36mv7jbar7y76l7kilvln04xqf6n-fontconfig-2.18.2-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/iv0yvsywa1v35xzdkqz9wdzhg7vshpdd-fontconfig-2.18.2-lib"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/qdbcjg7j3rxr1bvh1qhldk5aqjz7vlx6-fontconfig-2.18.2"
+            }
+          ],
+          "store_path": "/nix/store/122fcxcqy3ay3jkm3fa2bav0vb8mgdjy-fontconfig-2.18.2-bin"
+        }
+      }
+    },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
       "last_modified": "2026-06-30T12:14:11Z",
       "resolved": "github:NixOS/nixpkgs/e52c192be9d7b2c4bd4aed326c8731b35f8bb75c?lastModified=1782821651"
@@ -1367,170 +1441,6 @@
             }
           ],
           "store_path": "/nix/store/7plm1w55qdjpj349vbxbjqq1ja4zzf3m-libXfixes-6.0.1"
-        }
-      }
-    },
-    "xorg.libXi@1.8.2": {
-      "last_modified": "2025-10-07T08:41:47Z",
-      "resolved": "github:NixOS/nixpkgs/bce5fe2bb998488d8e7e7856315f90496723793c#xorg.libXi",
-      "source": "devbox-search",
-      "version": "1.8.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/i9kf1vypnih3hsksjvlw608rym41drn4-libXi-1.8.2",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/lgm5b4ib7ms20hc410cn56h8k31cv6r5-libXi-1.8.2-man",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/vz2145aibxnz34p1rn0k5anf7ymh147h-libXi-1.8.2-dev"
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/99qbk55q3h4dv5d9x3sm26jzv7b4vh4p-libXi-1.8.2-doc"
-            }
-          ],
-          "store_path": "/nix/store/i9kf1vypnih3hsksjvlw608rym41drn4-libXi-1.8.2"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/l5c4w2ayd9ffm6z3j5gb2vqkwsjlzl69-libXi-1.8.2",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/0f5633zfq9irz04xh86msywb3dw6h510-libXi-1.8.2-man",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/g9qgx9w8wj3jhvr80cyzb3szcg8yc3l5-libXi-1.8.2-dev"
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/l13z2729z069a2ywn61lldkqm47r1pjb-libXi-1.8.2-doc"
-            }
-          ],
-          "store_path": "/nix/store/l5c4w2ayd9ffm6z3j5gb2vqkwsjlzl69-libXi-1.8.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/b6hak91sbwj0cngywrb236f179r38y3c-libXi-1.8.2",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/wkjrj121g3s9g4rvcl411k195xy31w2m-libXi-1.8.2-man",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/8wzbhcgb1ghag4b883wpn4gzdjq0riii-libXi-1.8.2-dev"
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/ndwrw0pqnwsmw1q2sspddjx0i1scwnl2-libXi-1.8.2-doc"
-            }
-          ],
-          "store_path": "/nix/store/b6hak91sbwj0cngywrb236f179r38y3c-libXi-1.8.2"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/6nk1smsrxzsjcppwljylwa9swfiavfy1-libXi-1.8.2",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/iagca52p1cddxn9n4akag980gp94fp2c-libXi-1.8.2-man",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/lnrprzw8rwznjkdc2jmgcys90rkgsbcn-libXi-1.8.2-dev"
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/qcb8dnccp2cna09b4ryzyfp0fs1g7hv3-libXi-1.8.2-doc"
-            }
-          ],
-          "store_path": "/nix/store/6nk1smsrxzsjcppwljylwa9swfiavfy1-libXi-1.8.2"
-        }
-      }
-    },
-    "xorg.libXinerama@1.1.5": {
-      "last_modified": "2025-10-07T08:41:47Z",
-      "resolved": "github:NixOS/nixpkgs/bce5fe2bb998488d8e7e7856315f90496723793c#xorg.libXinerama",
-      "source": "devbox-search",
-      "version": "1.1.5",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/b65x28ssza2lm7jydq9lrhkjhfbinxdn-libXinerama-1.1.5",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/w34ghyd0panbjv66ij5chgcb955la9bi-libXinerama-1.1.5-dev"
-            }
-          ],
-          "store_path": "/nix/store/b65x28ssza2lm7jydq9lrhkjhfbinxdn-libXinerama-1.1.5"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/wjbxxvxwnfrlhwc36xcxji20sigyandl-libXinerama-1.1.5",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/nnw9kl6nfsph60by0d69wjbghqrc6khm-libXinerama-1.1.5-dev"
-            }
-          ],
-          "store_path": "/nix/store/wjbxxvxwnfrlhwc36xcxji20sigyandl-libXinerama-1.1.5"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/27sb0gjyiva170k6px885mf5s6h3vyvb-libXinerama-1.1.5",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/9bp5m3bh5jfi7w4bv331g6dc401w3mqx-libXinerama-1.1.5-dev"
-            }
-          ],
-          "store_path": "/nix/store/27sb0gjyiva170k6px885mf5s6h3vyvb-libXinerama-1.1.5"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/myjpnmphdy2clfj960lnidw5cfsw05i6-libXinerama-1.1.5",
-              "default": true
-            },
-            {
-              "name": "dev",
-              "path": "/nix/store/sfzsyd3dk4gxqp5ppbrdhya10klgb0bd-libXinerama-1.1.5-dev"
-            }
-          ],
-          "store_path": "/nix/store/myjpnmphdy2clfj960lnidw5cfsw05i6-libXinerama-1.1.5"
         }
       }
     },

--- a/justfile
+++ b/justfile
@@ -599,8 +599,8 @@ test-linux:
     FROM golang:1.26
     RUN apt-get update -qq && apt-get install -y -qq \
         libcairo2-dev libwayland-dev libx11-dev libxtst-dev libxrandr-dev \
-        libxinerama-dev libxfixes-dev libxkbcommon-dev wayland-protocols \
-        libei-dev liboeffis-dev libxi-dev libxrender-dev libfontconfig1-dev \
+        libxrender-dev libxext-dev libxfixes-dev libxkbcommon-dev \
+        libei-dev liboeffis-dev libfontconfig-dev \
         libtesseract-dev tesseract-ocr-eng libpipewire-0.3-dev \
         pkg-config >/dev/null 2>&1
     DOCKERFILE
@@ -658,8 +658,8 @@ lint-cross:
     FROM golang:1.26
     RUN apt-get update -qq && apt-get install -y -qq \
         libcairo2-dev libwayland-dev libx11-dev libxtst-dev libxrandr-dev \
-        libxinerama-dev libxfixes-dev libxkbcommon-dev wayland-protocols \
-        libei-dev liboeffis-dev libxi-dev libxrender-dev libfontconfig1-dev \
+        libxrender-dev libxext-dev libxfixes-dev libxkbcommon-dev \
+        libei-dev liboeffis-dev libfontconfig-dev \
         libtesseract-dev tesseract-ocr-eng libpipewire-0.3-dev \
         pkg-config >/dev/null 2>&1
     BASE

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,6 +20,7 @@
   libxrandr,
   libxrender,
   libxtst,
+  libxi,
   fontconfig,
   # tesseract backs the `vision` hint strategy on Linux. It is a required
   # dependency rather than an optional one: neru links libtesseract dynamically,
@@ -109,6 +110,7 @@ if useZip then
       libxrandr
       libxrender
       libxtst
+      libxi
       fontconfig
       tesseract
       pipewire
@@ -227,6 +229,7 @@ else
         libxrandr
         libxrender
         libxtst
+        libxi
         fontconfig
         tesseract
         pipewire

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,7 +20,7 @@
   libxrandr,
   libxrender,
   libxtst,
-  libxi,
+  fontconfig,
   # tesseract backs the `vision` hint strategy on Linux. It is a required
   # dependency rather than an optional one: neru links libtesseract dynamically,
   # so a missing library stops the daemon before any neru code runs, whatever
@@ -109,7 +109,7 @@ if useZip then
       libxrandr
       libxrender
       libxtst
-      libxi
+      fontconfig
       tesseract
       pipewire
     ];
@@ -227,7 +227,7 @@ else
         libxrandr
         libxrender
         libxtst
-        libxi
+        fontconfig
         tesseract
         pipewire
       ]


### PR DESCRIPTION
## Description

This PR makes every Linux dependency list declare what the cgo build actually links. The CI workflow, the release workflow, the two justfile container images, the Nix package and devbox all named Xinerama, which nothing in the tree uses, and none of them named fontconfig even though the Linux build asks pkg-config for it. The apt lists were also missing Xrender and Xext, which the X11 overlay links. Builds worked only because cairo's development package drags all three in, so nothing was broken for a user, but the lists lied about what a distro or a packager has to provide.

Each list now matches the set the cgo directives request. Xi is dropped alongside Xinerama where it appeared. The generated Wayland protocol sources are committed, so wayland-protocols stays only as the regeneration-recipe dependency it already was.

Nothing changes for a user of a release binary. Someone packaging from source gets an accurate list.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] N/A — This PR does not touch platform-specific code (build inputs only, no Go or C changes)

## General Checklist

- [x] Code formatted (`just fmt`) — N/A, no Go or Objective-C changed
- [x] `just ci` passes — build-input change with no Go diff: `just fmt-check && just lint` green on this host. The Linux legs of CI on this PR are the real check that the apt lists resolve; the Nix package was evaluated for x86_64-linux and its build inputs list the intended set.
- [x] Tests added/updated for new or changed functionality — N/A
- [x] Documentation updated (if applicable) — the setup guide's matching lists are in #1646
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Additional Context

The set every list now agrees on, taken from the `#cgo linux pkg-config` directives: cairo, fontconfig, libei, liboeffis, libpipewire, tesseract, wayland-client, x11, xext, xfixes, xkbcommon, xrandr, xrender, xtst. Fedora and Arch ship liboeffis inside libei, which the setup guide already notes.

devbox pins fontconfig at 2.18.2, the newest version its search reports; the lock was resolved with `devbox update fontconfig`.
