### PR TITLE
fix(windows): keep idle overlays responsive

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,7 +486,9 @@ its own.
    Linux, Direct2D on a DirectComposition swapchain on Windows (GDI on a
    layered window where that cannot come up). The Windows draw queues
    commands and returns; a dedicated UI thread paints and presents them,
-   coalescing frames, so no keystroke waits on pixels.
+   coalescing frames, so no keystroke waits on pixels. Between draws that thread
+   waits on the Win32 message queue, and queued Go callbacks post a native
+   wakeup. Windows messages are therefore serviced even when the overlay is idle.
 
 ---
 

--- a/internal/adapter/platform/windows/overlay_ui.go
+++ b/internal/adapter/platform/windows/overlay_ui.go
@@ -12,15 +12,19 @@ import (
 // Dedicated Win32 UI thread with a message pump for HWND creation and painting.
 // Does not implement overlay drawing; overlay.go marshals HWND work here.
 var (
-	overlayUIOnce sync.Once
-	overlayUIOps  chan func()
-	overlayUIGID  atomic.Uint64
+	overlayUIOnce                   sync.Once
+	overlayUIOps                    chan func()
+	overlayUIGID                    atomic.Uint64
+	overlayUIThreadID               uintptr
+	procMsgWaitForMultipleObjectsEx = user32.NewProc("MsgWaitForMultipleObjectsEx")
 )
 
 const (
 	overlayUIOpsBuffer = 256
 	goroutinePrefixLen = len("goroutine ")
 	decimalBase        = 10
+	qsAllInput         = 0x04FF
+	mwmoInputAvailable = 0x0004
 )
 
 type winMsg struct {
@@ -43,11 +47,26 @@ func startOverlayUIThread() {
 		go func() {
 			runtime.LockOSThread()
 			overlayUIGID.Store(curGoroutineID())
+
+			overlayUIThreadID, _, _ = procGetCurrentThreadID.Call()
+			// Create the native queue before producers can post its wakeup.
+			pumpOverlayMessages()
 			close(ready)
 
-			for fn := range overlayUIOps {
-				fn()
+			for {
 				pumpOverlayMessages()
+
+				select {
+				case callback := <-overlayUIOps:
+					callback()
+				default:
+					// A Go channel wait cannot service HWND messages. Wake for
+					// native input as well as the WM_NULL posted with callbacks.
+					// INPUTAVAILABLE also wakes for a bounded pump's leftovers.
+					discardCall(procMsgWaitForMultipleObjectsEx.Call(
+						0, 0, uintptr(^uint32(0)), qsAllInput, mwmoInputAvailable,
+					))
+				}
 			}
 		}()
 
@@ -66,10 +85,10 @@ func runOnOverlayUI(callback func()) {
 	}
 
 	done := make(chan struct{})
-	overlayUIOps <- func() {
+	queueOverlayUI(func() {
 		callback()
 		close(done)
-	}
+	})
 
 	<-done
 }
@@ -87,7 +106,14 @@ func postOnOverlayUI(callback func()) {
 		return
 	}
 
+	queueOverlayUI(callback)
+}
+
+func queueOverlayUI(callback func()) {
 	overlayUIOps <- callback
+	// Publish the callback first so a wakeup cannot run ahead of its work.
+	// WM_NULL needs no window and is harmless if another pump consumes it.
+	discardCall(procPostThreadMessageW.Call(overlayUIThreadID, 0, 0, 0))
 }
 
 func curGoroutineID() uint64 {

--- a/internal/adapter/platform/windows/overlay_ui_integration_windows_test.go
+++ b/internal/adapter/platform/windows/overlay_ui_integration_windows_test.go
@@ -1,0 +1,113 @@
+//go:build integration && windows
+
+package windows
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestOverlayUI_RespondsToSentMessagesWhileIdle(t *testing.T) {
+	hwnd := newIdleOverlayTestWindow(t)
+
+	var result uintptr
+
+	// SMTO_ABORTIFHUNG bounds the probe without sending keyboard input or
+	// queueing an overlay callback that would mask an idle message-pump bug.
+	const abortIfHung = 0x0002
+
+	ret, _, err := user32.NewProc("SendMessageTimeoutW").Call(
+		hwnd, 0, 0, 0, abortIfHung, 1000, uintptr(unsafe.Pointer(&result)),
+	)
+	if ret == 0 {
+		t.Fatalf("idle overlay thread did not answer WM_NULL: %v", err)
+	}
+}
+
+func TestOverlayUI_DispatchesQueuedMessagesWhileIdle(t *testing.T) {
+	hwnd := newIdleOverlayTestWindow(t)
+
+	const closeMessage = 0x0010
+
+	ret, _, err := procPostMessageW.Call(hwnd, closeMessage, 0, 0)
+	if ret == 0 {
+		t.Fatalf("PostMessageW: %v", err)
+	}
+
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		alive, _, _ := procIsWindow.Call(hwnd)
+		if alive == 0 {
+			return
+		}
+
+		select {
+		case <-ticker.C:
+		case <-deadline.C:
+			t.Fatal("idle overlay thread did not dispatch WM_CLOSE")
+		}
+	}
+}
+
+func TestOverlayUI_PostedCallbackWakesIdleThread(t *testing.T) {
+	_ = newIdleOverlayTestWindow(t)
+	done := make(chan struct{})
+
+	postOnOverlayUI(func() {
+		// Reentrant UI work must still run inline rather than wait on itself.
+		runOnOverlayUI(func() { close(done) })
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("posted callback did not wake the idle overlay thread")
+	}
+}
+
+func newIdleOverlayTestWindow(t *testing.T) uintptr {
+	t.Helper()
+
+	className, err := windows.UTF16PtrFromString("STATIC")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hwnd uintptr
+
+	var createErr error
+	runOnOverlayUI(func() {
+		// Hidden, non-activating window: no desktop input or visible overlay.
+		hwnd, _, createErr = procCreateWindowExW.Call(
+			wsExToolWindow|wsExNoActivate, uintptr(unsafe.Pointer(className)),
+			0, wsPopup, 0, 0, 1, 1, 0, 0, moduleHandle(), 0,
+		)
+	})
+
+	if hwnd == 0 {
+		t.Fatalf("CreateWindowExW: %v", createErr)
+	}
+
+	t.Cleanup(func() {
+		runOnOverlayUI(func() {
+			alive, _, _ := procIsWindow.Call(hwnd)
+			if alive != 0 {
+				discardCall(procDestroyWindow.Call(hwnd))
+			}
+		})
+	})
+
+	// Let the creation callback's final pump finish before sending a probe.
+	// No further Go callbacks may wake the UI thread during the assertion.
+	time.Sleep(50 * time.Millisecond)
+
+	return hwnd
+}


### PR DESCRIPTION
## Executive summary

This PR keeps Windows overlays responsive while idle, preventing the “Not responding” state and opaque ghost window. **Human tested on Windows:** @raymond-w-ko confirmed the freeze is gone.

Prepared by GPT-6 Astra.

## Reasoning

The UI thread waited on a Go callback channel and only serviced Windows messages after another draw, so a keystroke revived an otherwise idle window. It now waits on native messages and receives a wakeup when drawing work is queued. This preserves asynchronous rendering without a polling timer.

## Related Issues

None.

## Target Platform

- [x] Windows

## Type of Change

- [x] `fix` — Bug fix

## Cross-Platform Checklist

- [x] Windows build tags; no shared-code darwin imports.
- [x] Additional stubs — N/A, no new interface or capability.

## General Checklist

- [x] Formatting checked with `just fmt-check` and `just lint`.
- [x] `just ci` passes on Windows, including cross-platform checks and the vulnerability scan.
- [x] Native regression tests added for idle sent messages, queued messages, and callback wakeups.
- [x] Architecture documentation updated.
- [x] Conventional PR title describing the user-visible fix.

## Additional Context

Both idle-message probes failed before the fix and pass afterward. Native tests also passed 10 runs under the race detector; all six windows in the restarted daemon answered after six seconds idle. Platform-boundary review found no issues.