### PR TITLE
feat(hints): make the contour detector's thresholds configurable

### DIFF
--- a/configs/default-config.toml
+++ b/configs/default-config.toml
@@ -193,6 +193,20 @@ image_min_size = 48                          # Minimum width/height for image el
 checkbox_max_size = 32                       # Maximum width/height for checkbox elements (px)
 generic_clickable_min_confidence = 0.5       # Minimum confidence for generic clickable classification
 
+[hints.contour]
+request_timeout_ms = 2000                    # Timeout for one contour pass in milliseconds
+edge_low_threshold = 70                      # Canny hysteresis low, the gradient magnitude that extends an edge (0-255 luma)
+edge_high_threshold = 220                    # Canny hysteresis high, the gradient magnitude that starts an edge. Lower finds fainter outlines
+min_target_width = 7.0                       # Blobs this wide or narrower are noise (logical px)
+min_target_height = 3.0                      # Blobs this tall or shorter are noise (logical px)
+max_target_width = 650.0                     # Blobs this wide or wider are layout, not targets (logical px)
+max_target_height = 160.0                    # Blobs this tall or taller are layout, not targets (logical px)
+flat_line_height = 6.0                       # Nested strokes no taller than this are dropped (hamburger lines)
+container_height = 50.0                      # Height from which a blob counts as a card or dialog. Its button-sized children are the targets
+same_center_slack = 8.0                      # Nested blob within this many px of its parent's centre duplicates it
+square_icon_size = 40.0                      # Square parents smaller than this keep their box and drop their inner detail
+square_icon_slack = 5.0                      # How far from square (|w-h|) that parent may be
+
 # Grid mode
 # See https://github.com/y3owk1n/neru/blob/main/docs/CONFIGURATION.md#grid
 [grid]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1085,7 +1085,7 @@ The `contour` strategy is one pure-Go pass over the captured pixels, so every
 option below is read on all three platforms. The defaults are
 [wl-kbptr](https://github.com/moverest/wl-kbptr)'s numbers. Sizes are logical
 pixels (points on a Retina display). The two edge thresholds are Sobel
-gradient magnitudes on a 0..255 grayscale frame. Lower the edge thresholds to
+gradient magnitudes on a 0..255 grayscale frame, at most 1530. Lower the edge thresholds to
 pick up faint outlines on low-contrast themes, raise them to cut clutter. Widen
 the target bounds to hint notification cards and toasts, narrow them to drop
 them.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -840,7 +840,7 @@ Explicit component colors override theme derivation. Omitted colors inherit from
 Labels clickable UI elements with short overlay labels. By default uses the platform accessibility tree (`axtree` strategy). Two screen-capture strategies exist for apps whose accessibility tree is too thin to hint from; both scan the focused window by default (`capture_scope` widens that to the whole screen), and both add the system surfaces the `include_*` options ask for from the accessibility tree:
 
 - `vision`: on-screen recognition. The Vision framework on macOS (text plus rectangles), tesseract OCR on Linux and `Windows.Media.Ocr` on Windows (text only). Detected text becomes the element's title, so hint search (`--search`) and `--split-word` work. Costs an ML or OCR pass per activation; Linux needs tesseract installed and Windows an OCR language pack.
-- `contour`: edge and contour analysis of the window pixels, an algorithm ported from [wl-kbptr](https://github.com/moverest/wl-kbptr). Finds anything with a visible outline (buttons, icons, toolbar items, text runs) in a few milliseconds with no external dependency. Elements carry no text, so search and word splitting do not apply, and `hints.vision.*` is not read.
+- `contour`: edge and contour analysis of the window pixels, an algorithm ported from [wl-kbptr](https://github.com/moverest/wl-kbptr). Finds anything with a visible outline (buttons, icons, toolbar items, text runs) in a few milliseconds with no external dependency. Elements carry no text, so search and word splitting do not apply, and `hints.vision.*` is not read. The detector's own numbers are under [`[hints.contour]`](#contour-options).
 
 Pick `vision` when you want to type what you see, or the app is text-heavy. Pick `contour` when latency matters, the targets are icons rather than words, or OCR is not installed. Both are overridable per-app.
 
@@ -1077,6 +1077,48 @@ link_min_width = 50
 image_min_size = 48
 checkbox_max_size = 32
 generic_clickable_min_confidence = 0.5
+```
+
+### Contour options
+
+The `contour` strategy is one pure-Go pass over the captured pixels, so every
+option below is read on all three platforms. The defaults are
+[wl-kbptr](https://github.com/moverest/wl-kbptr)'s numbers. Sizes are logical
+pixels (points on a Retina display). The two edge thresholds are Sobel
+gradient magnitudes on a 0..255 grayscale frame. Lower the edge thresholds to
+pick up faint outlines on low-contrast themes, raise them to cut clutter. Widen
+the target bounds to hint notification cards and toasts, narrow them to drop
+them.
+
+| Option                | Type  | Default | Description                                                                                                  |
+| --------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `request_timeout_ms`  | int   | `2000`  | Time budget for one contour pass. A pass that runs over the budget returns no targets.                       |
+| `edge_low_threshold`  | int   | `70`    | Canny hysteresis low. Gradient magnitude that extends an edge already found. Must be at most the high value. |
+| `edge_high_threshold` | int   | `220`   | Canny hysteresis high. Gradient magnitude that starts an edge. Lower finds fainter outlines.                 |
+| `min_target_width`    | float | `7.0`   | Blobs this wide or narrower are noise.                                                                       |
+| `min_target_height`   | float | `3.0`   | Blobs this tall or shorter are noise.                                                                        |
+| `max_target_width`    | float | `650.0` | Blobs this wide or wider are layout containers, not targets.                                                 |
+| `max_target_height`   | float | `160.0` | Blobs this tall or taller are layout containers, not targets.                                                |
+| `flat_line_height`    | float | `6.0`   | Strokes nested in another target and no taller than this are dropped (hamburger lines, underlines).          |
+| `container_height`    | float | `50.0`  | Height from which a blob counts as a card or dialog. One holding button-sized children is dropped for them.  |
+| `same_center_slack`   | float | `8.0`   | A nested blob whose centre is within this many pixels of its parent's is a duplicate of the parent.          |
+| `square_icon_size`    | float | `40.0`  | A roughly square parent smaller than this keeps its box, and its inner detail (the icon artwork) is dropped. |
+| `square_icon_slack`   | float | `5.0`   | How far from square, as width minus height, that parent may be.                                              |
+
+```toml
+[hints.contour]
+request_timeout_ms = 2000
+edge_low_threshold = 70
+edge_high_threshold = 220
+min_target_width = 7.0
+min_target_height = 3.0
+max_target_width = 650.0
+max_target_height = 160.0
+flat_line_height = 6.0
+container_height = 50.0
+same_center_slack = 8.0
+square_icon_size = 40.0
+square_icon_slack = 5.0
 ```
 
 ### Choosing a label direction

--- a/internal/adapter/vision/adapter_darwin.go
+++ b/internal/adapter/vision/adapter_darwin.go
@@ -224,6 +224,7 @@ func (a *Adapter) Health(ctx context.Context) error {
 func (a *Adapter) DetectContours(
 	ctx context.Context,
 	screenBounds image.Rectangle,
+	cfg config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	select {
 	case <-ctx.Done():
@@ -266,7 +267,7 @@ func (a *Adapter) DetectContours(
 
 	origin := image.Pt(int(displayBounds.origin.x), int(displayBounds.origin.y))
 
-	rects, err := contour.Detect(img, scale)
+	rects, err := contour.Detect(ctx, img, scale, contour.ParamsFromConfig(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/vision/adapter_linux.go
+++ b/internal/adapter/vision/adapter_linux.go
@@ -161,6 +161,7 @@ func (a *Adapter) CaptureScreen(ctx context.Context) (*image.RGBA, error) {
 func (a *Adapter) DetectContours(
 	ctx context.Context,
 	screenBounds image.Rectangle,
+	cfg config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	select {
 	case <-ctx.Done():
@@ -187,7 +188,7 @@ func (a *Adapter) DetectContours(
 		scale = float64(img.Rect.Dy()) / float64(region.Dy())
 	}
 
-	rects, err := contour.Detect(img, scale)
+	rects, err := contour.Detect(ctx, img, scale, contour.ParamsFromConfig(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/vision/adapter_other.go
+++ b/internal/adapter/vision/adapter_other.go
@@ -31,6 +31,7 @@ func (a *Adapter) DetectElements(
 func (a *Adapter) DetectContours(
 	_ context.Context,
 	_ image.Rectangle,
+	_ config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	return nil, derrors.New(
 		derrors.CodeNotSupported,

--- a/internal/adapter/vision/adapter_stub_contract_other_test.go
+++ b/internal/adapter/vision/adapter_stub_contract_other_test.go
@@ -64,7 +64,11 @@ func TestVisionAdapter_AllMethodsReportNotSupportedOffDarwin(t *testing.T) {
 		{
 			name: "DetectContours",
 			call: func() error {
-				_, err := adapter.DetectContours(ctx, image.Rect(0, 0, 100, 100))
+				_, err := adapter.DetectContours(
+					ctx,
+					image.Rect(0, 0, 100, 100),
+					config.DefaultConfig().Hints.Contour,
+				)
 
 				return err
 			},
@@ -112,7 +116,11 @@ func TestVisionAdapter_StubsReturnNoPartialResults(t *testing.T) {
 			len(elements))
 	}
 
-	contours, err := adapter.DetectContours(ctx, image.Rect(0, 0, 100, 100))
+	contours, err := adapter.DetectContours(
+		ctx,
+		image.Rect(0, 0, 100, 100),
+		config.DefaultConfig().Hints.Contour,
+	)
 	if err == nil {
 		t.Fatal("DetectContours returned a nil error")
 	}

--- a/internal/adapter/vision/adapter_stub_contract_windows_test.go
+++ b/internal/adapter/vision/adapter_stub_contract_windows_test.go
@@ -102,7 +102,11 @@ func TestVisionAdapter_CaptureAnswersOnWindows(t *testing.T) {
 		)
 	}
 
-	elements, err := adapter.DetectContours(ctx, image.Rect(0, 0, 100, 100))
+	elements, err := adapter.DetectContours(
+		ctx,
+		image.Rect(0, 0, 100, 100),
+		config.DefaultConfig().Hints.Contour,
+	)
 	if err != nil && elements != nil {
 		t.Errorf("DetectContours returned %d elements alongside its error %v", len(elements), err)
 	}
@@ -123,7 +127,11 @@ func TestVisionAdapter_DetectionRefusesAnEmptyRegion(t *testing.T) {
 	adapter := vision.NewAdapter(nil)
 	ctx := context.Background()
 
-	contours, err := adapter.DetectContours(ctx, image.Rectangle{})
+	contours, err := adapter.DetectContours(
+		ctx,
+		image.Rectangle{},
+		config.DefaultConfig().Hints.Contour,
+	)
 	if err == nil {
 		t.Fatalf("DetectContours accepted an empty region and returned %d elements", len(contours))
 	}

--- a/internal/adapter/vision/adapter_windows.go
+++ b/internal/adapter/vision/adapter_windows.go
@@ -158,6 +158,7 @@ func (a *Adapter) CaptureScreen(ctx context.Context) (*image.RGBA, error) {
 func (a *Adapter) DetectContours(
 	ctx context.Context,
 	screenBounds image.Rectangle,
+	cfg config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	select {
 	case <-ctx.Done():
@@ -181,7 +182,7 @@ func (a *Adapter) DetectContours(
 
 	// The process is per-monitor-v2 DPI aware, so the frame is the region's own
 	// size in physical pixels and the scale is one.
-	rects, err := contour.Detect(img, 1)
+	rects, err := contour.Detect(ctx, img, 1, contour.ParamsFromConfig(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adapter/vision/contour/detect.go
+++ b/internal/adapter/vision/contour/detect.go
@@ -110,7 +110,15 @@ func Detect(
 		return nil, err
 	}
 
-	return filterTargets(comps, scale, params), nil
+	rects := filterTargets(comps, scale, params)
+
+	// Nothing leaves after the deadline, however far the pass got.
+	err = checkDeadline(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return rects, nil
 }
 
 func checkDeadline(ctx context.Context) error {

--- a/internal/adapter/vision/contour/detect.go
+++ b/internal/adapter/vision/contour/detect.go
@@ -1,28 +1,44 @@
 package contour
 
 import (
+	"context"
 	"image"
 	"math"
 
 	"github.com/y3owk1n/neru/internal/derrors"
 )
 
-// Canny thresholds and the size heuristics below are wl-kbptr's numbers,
-// kept verbatim so the detector finds the same targets its origin does.
-const (
-	cannyLow  = 70
-	cannyHigh = 220
+// Params are the detector's tunable numbers. wl-kbptr's values are the
+// defaults the config package ships as hints.contour. The detector takes
+// whatever it is handed. Validation happens at config load.
+//
+// Thresholds are Sobel gradient magnitudes on a 0..255 luma frame. Sizes are
+// logical pixels, after dividing by the frame scale.
+type Params struct {
+	// EdgeLowThreshold and EdgeHighThreshold are the Canny hysteresis pair:
+	// pixels above high start an edge, pixels above low extend one.
+	EdgeLowThreshold  int
+	EdgeHighThreshold int
 
-	maxTargetHeight = 160.0
-	maxTargetWidth  = 650.0
-	minTargetHeight = 3.0
-	minTargetWidth  = 7.0
-	flatLineHeight  = 6.0
-	containerHeight = 50.0
-	sameCenterSlack = 8.0
-	squareIconSlack = 5.0
-	squareIconSize  = 40.0
-)
+	// Blobs outside these bounds are noise (below) or layout containers (above).
+	MinTargetWidth  float64
+	MinTargetHeight float64
+	MaxTargetWidth  float64
+	MaxTargetHeight float64
+
+	// FlatLineHeight drops nested strokes no taller than this (menu lines).
+	FlatLineHeight float64
+	// ContainerHeight is where a blob starts counting as a card or dialog
+	// whose children are the real targets.
+	ContainerHeight float64
+	// SameCenterSlack is how close to its parent's center a nested blob
+	// must be to count as a duplicate of it.
+	SameCenterSlack float64
+	// SquareIconSize and SquareIconSlack describe a roughly square parent
+	// small enough that its inner detail is the icon's own artwork.
+	SquareIconSize  float64
+	SquareIconSlack float64
+}
 
 // component is one 8-connected blob of dilated edge pixels with its place in
 // the enclosure hierarchy. Indices are into the components slice; -1 is none.
@@ -43,8 +59,14 @@ func (c component) area() int64 {
 // scale-dependent dilation, connected components and hierarchical filtering.
 // Rectangles are returned in logical coordinates (divided by scale). An empty
 // frame is refused; a frame with nothing in it returns no rectangles and no
-// error.
-func Detect(img *image.RGBA, scale float64) ([]image.Rectangle, error) {
+// error. The context is checked between stages, so a deadline set by the
+// caller ends a slow frame early instead of after the fact.
+func Detect(
+	ctx context.Context,
+	img *image.RGBA,
+	scale float64,
+	params Params,
+) ([]image.Rectangle, error) {
 	if img == nil || img.Rect.Dx() <= 0 || img.Rect.Dy() <= 0 {
 		return nil, derrors.New(
 			derrors.CodeInvalidInput,
@@ -60,12 +82,33 @@ func Detect(img *image.RGBA, scale float64) ([]image.Rectangle, error) {
 
 	gray := grayscale(img.Pix, width, height, img.Stride)
 	blurred := gaussianBlur(gray, width, height)
-	edges := cannyEdges(blurred, width, height)
+
+	err := checkDeadline(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	edges := cannyEdges(blurred, width, height, params)
 	dilated := dilate(edges, width, height, scale)
+
+	err = checkDeadline(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	comps := connectedComponents(dilated, width, height)
 	buildHierarchy(comps)
 
-	return filterTargets(comps, scale), nil
+	return filterTargets(comps, scale, params), nil
+}
+
+func checkDeadline(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return derrors.Wrap(ctx.Err(), derrors.CodeContextCanceled, "contour detection canceled")
+	default:
+		return nil
+	}
 }
 
 // grayscale converts RGBA to luma with ITU-R BT.601 integer arithmetic.
@@ -131,7 +174,9 @@ func gaussianBlur(gray []uint8, width, height int) []uint8 {
 // and hysteresis thresholding. The result is 255 on edge pixels, 0 elsewhere.
 //
 //nolint:varnamelen,mnd // pixel kernel: coordinates and kernel coefficients read as the algorithm writes them
-func cannyEdges(blurred []uint8, width, height int) []uint8 {
+func cannyEdges(blurred []uint8, width, height int, params Params) []uint8 {
+	cannyLow := int16(params.EdgeLowThreshold)
+	cannyHigh := int16(params.EdgeHighThreshold)
 	total := width * height
 	mag := make([]int16, total)
 	dir := make([]uint8, total)
@@ -381,7 +426,7 @@ func buildHierarchy(comps []component) {
 // component order.
 //
 //nolint:varnamelen,mnd // pixel kernel: coordinates and kernel coefficients read as the algorithm writes them
-func filterTargets(comps []component, scale float64) []image.Rectangle {
+func filterTargets(comps []component, scale float64, params Params) []image.Rectangle {
 	n := len(comps)
 	filtered := make([]bool, n)
 	rx := make([]float64, n)
@@ -397,9 +442,9 @@ func filterTargets(comps []component, scale float64) []image.Rectangle {
 
 		// Buttons and small inputs are typically under 50px high, but
 		// notification cards, toasts and floating dialogs can reach 160px high
-		// and 650px wide. Below the minimums is noise.
-		if rh[i] >= maxTargetHeight || rw[i] >= maxTargetWidth ||
-			rh[i] <= minTargetHeight || rw[i] <= minTargetWidth {
+		// and 650px wide with the shipped bounds. Below the minimums is noise.
+		if rh[i] >= params.MaxTargetHeight || rw[i] >= params.MaxTargetWidth ||
+			rh[i] <= params.MinTargetHeight || rw[i] <= params.MinTargetWidth {
 			filtered[i] = true
 		}
 	}
@@ -424,7 +469,7 @@ func filterTargets(comps []component, scale float64) []image.Rectangle {
 			case p >= 0 && filtered[p]:
 				// The parent is a layout container (dialog, card), not a
 				// button, so children inside it are kept as they are.
-			case rh[i] <= flatLineHeight:
+			case rh[i] <= params.FlatLineHeight:
 				// Flat inner lines, such as hamburger menu strokes.
 				filtered[i] = true
 			case p >= 0:
@@ -435,9 +480,9 @@ func filterTargets(comps []component, scale float64) []image.Rectangle {
 
 				// Inner targets sharing the parent's center, and inner detail
 				// of square icons, duplicate the parent.
-				if (math.Abs(cx-pcx) < sameCenterSlack && math.Abs(cy-pcy) < sameCenterSlack) ||
-					(math.Abs(rh[p]-rw[p]) < squareIconSlack &&
-						rh[p] < squareIconSize && rw[p] < squareIconSize) {
+				if (math.Abs(cx-pcx) < params.SameCenterSlack && math.Abs(cy-pcy) < params.SameCenterSlack) ||
+					(math.Abs(rh[p]-rw[p]) < params.SquareIconSlack &&
+						rh[p] < params.SquareIconSize && rw[p] < params.SquareIconSize) {
 					filtered[i] = true
 				}
 			}
@@ -448,16 +493,17 @@ func filterTargets(comps []component, scale float64) []image.Rectangle {
 		}
 	}
 
-	// A container (50 <= height < 160) holding button-sized children is a
-	// dialog whose buttons are the targets; one holding none is a toast and
-	// stays clickable itself.
+	// A container (at least ContainerHeight tall, under the max) holding
+	// button-sized children is a dialog whose buttons are the targets; one
+	// holding none is a toast and stays clickable itself.
 	for i := range comps {
-		if filtered[i] || rh[i] < containerHeight {
+		if filtered[i] || rh[i] < params.ContainerHeight {
 			continue
 		}
 
 		for child := comps[i].firstChild; child >= 0; child = comps[child].nextSibling {
-			if !filtered[child] && rh[child] < containerHeight && rh[child] > flatLineHeight {
+			if !filtered[child] && rh[child] < params.ContainerHeight &&
+				rh[child] > params.FlatLineHeight {
 				filtered[i] = true
 				break
 			}

--- a/internal/adapter/vision/contour/detect.go
+++ b/internal/adapter/vision/contour/detect.go
@@ -97,7 +97,18 @@ func Detect(
 	}
 
 	comps := connectedComponents(dilated, width, height)
+
+	err = checkDeadline(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	buildHierarchy(comps)
+
+	err = checkDeadline(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	return filterTargets(comps, scale, params), nil
 }

--- a/internal/adapter/vision/contour/detect_test.go
+++ b/internal/adapter/vision/contour/detect_test.go
@@ -1,6 +1,7 @@
 package contour_test
 
 import (
+	"context"
 	"image"
 	"image/color"
 	"image/draw"
@@ -10,17 +11,34 @@ import (
 	"github.com/y3owk1n/neru/internal/adapter/vision/contour"
 )
 
+// testParams are wl-kbptr's numbers, the ones config ships as defaults.
+func testParams() contour.Params {
+	return contour.Params{
+		EdgeLowThreshold:  70,
+		EdgeHighThreshold: 220,
+		MinTargetWidth:    7,
+		MinTargetHeight:   3,
+		MaxTargetWidth:    650,
+		MaxTargetHeight:   160,
+		FlatLineHeight:    6,
+		ContainerHeight:   50,
+		SameCenterSlack:   8,
+		SquareIconSize:    40,
+		SquareIconSlack:   5,
+	}
+}
+
 func TestDetect_NilOrEmpty(t *testing.T) {
 	t.Parallel()
 
-	res, err := contour.Detect(nil, 1.0)
+	res, err := contour.Detect(context.Background(), nil, 1.0, testParams())
 	if err == nil || res != nil {
 		t.Errorf("Detect(nil) = %v, %v; want nil and an error", res, err)
 	}
 
 	empty := image.NewRGBA(image.Rect(0, 0, 0, 0))
 
-	res, err = contour.Detect(empty, 1.0)
+	res, err = contour.Detect(context.Background(), empty, 1.0, testParams())
 	if err == nil || res != nil {
 		t.Errorf("Detect(empty) = %v, %v; want nil and an error", res, err)
 	}
@@ -49,7 +67,7 @@ func TestDetect_ButtonDetection(t *testing.T) {
 		img.Set(btnRect.Max.X-1, y, black)
 	}
 
-	targets, err := contour.Detect(img, 1.0)
+	targets, err := contour.Detect(context.Background(), img, 1.0, testParams())
 	if err != nil {
 		t.Fatalf("Detect() error = %v", err)
 	}
@@ -104,7 +122,7 @@ func TestDetect_FiltersNoiseAndOversized(t *testing.T) {
 		img.Set(349, y, black)
 	}
 
-	targets, err := contour.Detect(img, 1.0)
+	targets, err := contour.Detect(context.Background(), img, 1.0, testParams())
 	if err != nil {
 		t.Fatalf("Detect() error = %v", err)
 	}
@@ -144,7 +162,7 @@ func TestDetect_NotificationCardWithoutButtons(t *testing.T) {
 		img.Set(card.Max.X-1, y, black)
 	}
 
-	targets, err := contour.Detect(img, 1.0)
+	targets, err := contour.Detect(context.Background(), img, 1.0, testParams())
 	if err != nil {
 		t.Fatalf("Detect() error = %v", err)
 	}
@@ -202,7 +220,7 @@ func TestDetect_ButtonInsideEnclosingContainer(t *testing.T) {
 		img.Set(btn.Max.X-1, y, black)
 	}
 
-	targets, err := contour.Detect(img, 1.0)
+	targets, err := contour.Detect(context.Background(), img, 1.0, testParams())
 	if err != nil {
 		t.Fatalf("Detect() error = %v", err)
 	}
@@ -237,7 +255,7 @@ func BenchmarkDetect_FullScreenFrame(b *testing.B) {
 	img := syntheticFrame(rand.New(rand.NewPCG(3, 4)), 2560, 1440)
 
 	for b.Loop() {
-		_, _ = contour.Detect(img, 2)
+		_, _ = contour.Detect(context.Background(), img, 2, testParams())
 	}
 }
 

--- a/internal/adapter/vision/contour/detect_test.go
+++ b/internal/adapter/vision/contour/detect_test.go
@@ -300,3 +300,20 @@ func syntheticFrame(rng *rand.Rand, width, height int) *image.RGBA {
 
 	return img
 }
+
+// TestDetect_ExpiredDeadlineReturnsNothing pins the time budget: a frame
+// handed in with a dead context yields no rectangles, only the cancel error.
+func TestDetect_ExpiredDeadlineReturnsNothing(t *testing.T) {
+	t.Parallel()
+
+	img := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	draw.Draw(img, img.Bounds(), &image.Uniform{color.White}, image.Point{}, draw.Src)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rects, err := contour.Detect(ctx, img, 1.0, testParams())
+	if err == nil || rects != nil {
+		t.Fatalf("Detect(canceled) = %v, %v; want nil and an error", rects, err)
+	}
+}

--- a/internal/adapter/vision/contour/params.go
+++ b/internal/adapter/vision/contour/params.go
@@ -1,0 +1,21 @@
+package contour
+
+import "github.com/y3owk1n/neru/internal/config"
+
+// ParamsFromConfig maps the hints.contour section onto the detector's
+// parameters. The timeout is not among them. The caller applies it to the context.
+func ParamsFromConfig(cfg config.HintsContourConfig) Params {
+	return Params{
+		EdgeLowThreshold:  cfg.EdgeLowThreshold,
+		EdgeHighThreshold: cfg.EdgeHighThreshold,
+		MinTargetWidth:    cfg.MinTargetWidth,
+		MinTargetHeight:   cfg.MinTargetHeight,
+		MaxTargetWidth:    cfg.MaxTargetWidth,
+		MaxTargetHeight:   cfg.MaxTargetHeight,
+		FlatLineHeight:    cfg.FlatLineHeight,
+		ContainerHeight:   cfg.ContainerHeight,
+		SameCenterSlack:   cfg.SameCenterSlack,
+		SquareIconSize:    cfg.SquareIconSize,
+		SquareIconSlack:   cfg.SquareIconSlack,
+	}
+}

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -143,7 +143,7 @@ func (s *HintService) GenerateHints(
 	case domain.StrategyVision:
 		elements = s.generateHintsVision(ctx, filter, captureScope, splitWord)
 	case domain.StrategyContour:
-		elements = s.generateHintsContour(ctx, filter, captureScope)
+		elements = s.generateHintsContour(ctx, filter, captureScope, cfg.Contour)
 	default:
 		elements, genErr = s.generateHintsAX(ctx, filter)
 	}
@@ -374,6 +374,7 @@ func (s *HintService) generateHintsContour(
 	ctx context.Context,
 	filter ports.ElementFilter,
 	captureScope string,
+	cfg config.HintsContourConfig,
 ) []*element.Element {
 	allElements := s.supplementaryElements(ctx, filter)
 
@@ -390,12 +391,12 @@ func (s *HintService) generateHintsContour(
 
 	contourCtx, cancel := context.WithTimeout(
 		ctx,
-		time.Duration(s.config.Contour.RequestTimeoutMS)*time.Millisecond,
+		time.Duration(cfg.RequestTimeoutMS)*time.Millisecond,
 	)
 	defer cancel()
 
 	contourStart := time.Now()
-	elements, err := s.vision.DetectContours(contourCtx, windowBounds, s.config.Contour)
+	elements, err := s.vision.DetectContours(contourCtx, windowBounds, cfg)
 	s.logger.Debug("TIMING: Window elements (contour)",
 		zap.Duration("elapsed", time.Since(contourStart)),
 		zap.Int("count", len(elements)),

--- a/internal/app/services/hint_service.go
+++ b/internal/app/services/hint_service.go
@@ -388,8 +388,14 @@ func (s *HintService) generateHintsContour(
 		return allElements
 	}
 
+	contourCtx, cancel := context.WithTimeout(
+		ctx,
+		time.Duration(s.config.Contour.RequestTimeoutMS)*time.Millisecond,
+	)
+	defer cancel()
+
 	contourStart := time.Now()
-	elements, err := s.vision.DetectContours(ctx, windowBounds)
+	elements, err := s.vision.DetectContours(contourCtx, windowBounds, s.config.Contour)
 	s.logger.Debug("TIMING: Window elements (contour)",
 		zap.Duration("elapsed", time.Since(contourStart)),
 		zap.Int("count", len(elements)),

--- a/internal/app/services/hint_service_test.go
+++ b/internal/app/services/hint_service_test.go
@@ -773,6 +773,7 @@ func (m *mockVisionPort) DetectElements(
 func (m *mockVisionPort) DetectContours(
 	context.Context,
 	image.Rectangle,
+	config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	if m.detectErr != nil {
 		return nil, m.detectErr
@@ -878,7 +879,7 @@ func TestHintService_GenerateHintsContourCombinesSupplementaryAndWindowElements(
 		},
 		logger.Get(),
 		&mocks.MockVisionPort{
-			DetectContoursFunc: func(context.Context, image.Rectangle) ([]*element.Element, error) {
+			DetectContoursFunc: func(context.Context, image.Rectangle, config.HintsContourConfig) ([]*element.Element, error) {
 				return []*element.Element{windowElement}, nil
 			},
 		},
@@ -924,7 +925,7 @@ func TestHintService_GenerateHintsContour_ScansFocusedWindow(t *testing.T) {
 	var capturedRegion image.Rectangle
 
 	mockVision := &mocks.MockVisionPort{
-		DetectContoursFunc: func(_ context.Context, region image.Rectangle) ([]*element.Element, error) {
+		DetectContoursFunc: func(_ context.Context, region image.Rectangle, _ config.HintsContourConfig) ([]*element.Element, error) {
 			capturedRegion = region
 
 			return []*element.Element{elem}, nil
@@ -986,7 +987,7 @@ func TestHintService_GenerateHintsContour_ScreenScopeSkipsTheWindow(t *testing.T
 	var capturedRegion image.Rectangle
 
 	mockVision := &mocks.MockVisionPort{
-		DetectContoursFunc: func(_ context.Context, region image.Rectangle) ([]*element.Element, error) {
+		DetectContoursFunc: func(_ context.Context, region image.Rectangle, _ config.HintsContourConfig) ([]*element.Element, error) {
 			capturedRegion = region
 
 			return nil, nil
@@ -1062,7 +1063,7 @@ func TestHintService_GenerateHintsContour_AppConfigWidensCaptureScope(t *testing
 		cfg,
 		zap.NewNop(),
 		&mocks.MockVisionPort{
-			DetectContoursFunc: func(_ context.Context, region image.Rectangle) ([]*element.Element, error) {
+			DetectContoursFunc: func(_ context.Context, region image.Rectangle, _ config.HintsContourConfig) ([]*element.Element, error) {
 				capturedRegion = region
 
 				return nil, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -374,6 +374,24 @@ type HintsVisionConfig struct {
 	GenericClickableMinConfidence float64 `json:"genericClickableMinConfidence" toml:"generic_clickable_min_confidence"`
 }
 
+// HintsContourConfig defines tunable settings for the contour strategy. The
+// shipped values are wl-kbptr's; sizes are logical pixels and the edge
+// thresholds are Sobel gradient magnitudes on a 0..255 luma frame.
+type HintsContourConfig struct {
+	RequestTimeoutMS  int     `json:"requestTimeoutMs"  toml:"request_timeout_ms"`
+	EdgeLowThreshold  int     `json:"edgeLowThreshold"  toml:"edge_low_threshold"`
+	EdgeHighThreshold int     `json:"edgeHighThreshold" toml:"edge_high_threshold"`
+	MinTargetWidth    float64 `json:"minTargetWidth"    toml:"min_target_width"`
+	MinTargetHeight   float64 `json:"minTargetHeight"   toml:"min_target_height"`
+	MaxTargetWidth    float64 `json:"maxTargetWidth"    toml:"max_target_width"`
+	MaxTargetHeight   float64 `json:"maxTargetHeight"   toml:"max_target_height"`
+	FlatLineHeight    float64 `json:"flatLineHeight"    toml:"flat_line_height"`
+	ContainerHeight   float64 `json:"containerHeight"   toml:"container_height"`
+	SameCenterSlack   float64 `json:"sameCenterSlack"   toml:"same_center_slack"`
+	SquareIconSize    float64 `json:"squareIconSize"    toml:"square_icon_size"`
+	SquareIconSlack   float64 `json:"squareIconSlack"   toml:"square_icon_slack"`
+}
+
 // HintsConfig defines the visual and behavioral settings for hints mode.
 type HintsConfig struct {
 	Enabled           bool                `json:"enabled"           toml:"enabled"`
@@ -386,6 +404,7 @@ type HintsConfig struct {
 	SearchInputUI     SearchInputUI       `json:"searchInputUi"     toml:"search_input_ui"`
 	BoundaryHighlight BoundaryHighlightUI `json:"boundaryHighlight" toml:"boundary_highlight"`
 	Vision            HintsVisionConfig   `json:"vision"            toml:"vision"`
+	Contour           HintsContourConfig  `json:"contour"           toml:"contour"`
 
 	IncludeMenubarHints           bool                `json:"includeMenubarHints"           toml:"include_menubar_hints"`
 	AdditionalMenubarHintsTargets []string            `json:"additionalMenubarHintsTargets" toml:"additional_menubar_hints_targets"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -58,6 +58,35 @@ const (
 	// DefaultVisionGenericClickableMinConfidence is the default generic clickable confidence threshold.
 	DefaultVisionGenericClickableMinConfidence = 0.5
 
+	// The contour defaults are wl-kbptr's numbers, kept verbatim so the
+	// detector finds the same targets its origin does.
+
+	// DefaultContourRequestTimeoutMS bounds one contour pass. The detector takes
+	// a few milliseconds on a window and stays under this on a full display.
+	DefaultContourRequestTimeoutMS = 2000
+	// DefaultContourEdgeLowThreshold extends an edge (Canny hysteresis low).
+	DefaultContourEdgeLowThreshold = 70
+	// DefaultContourEdgeHighThreshold starts an edge (Canny hysteresis high).
+	DefaultContourEdgeHighThreshold = 220
+	// DefaultContourMinTargetWidth is the width at or below which a blob is noise.
+	DefaultContourMinTargetWidth = 7.0
+	// DefaultContourMinTargetHeight is the height at or below which a blob is noise.
+	DefaultContourMinTargetHeight = 3.0
+	// DefaultContourMaxTargetWidth is the width at or above which a blob is layout.
+	DefaultContourMaxTargetWidth = 650.0
+	// DefaultContourMaxTargetHeight is the height at or above which a blob is layout.
+	DefaultContourMaxTargetHeight = 160.0
+	// DefaultContourFlatLineHeight drops nested strokes no taller than this.
+	DefaultContourFlatLineHeight = 6.0
+	// DefaultContourContainerHeight is where a blob starts counting as a dialog or card.
+	DefaultContourContainerHeight = 50.0
+	// DefaultContourSameCenterSlack is the center distance under which a nested blob duplicates its parent.
+	DefaultContourSameCenterSlack = 8.0
+	// DefaultContourSquareIconSize is the size under which a square parent drops its inner detail.
+	DefaultContourSquareIconSize = 40.0
+	// DefaultContourSquareIconSlack is how far from square that parent may be.
+	DefaultContourSquareIconSlack = 5.0
+
 	// DefaultSearchInputYOffset is the default Y offset for search input.
 	DefaultSearchInputYOffset = 24
 	// DefaultSearchInputWidth is the default width for search input.
@@ -486,6 +515,20 @@ func defaultHints() HintsConfig {
 			ImageMinSize:                  DefaultVisionImageMinSize,
 			CheckboxMaxSize:               DefaultVisionCheckboxMaxSize,
 			GenericClickableMinConfidence: DefaultVisionGenericClickableMinConfidence,
+		},
+		Contour: HintsContourConfig{
+			RequestTimeoutMS:  DefaultContourRequestTimeoutMS,
+			EdgeLowThreshold:  DefaultContourEdgeLowThreshold,
+			EdgeHighThreshold: DefaultContourEdgeHighThreshold,
+			MinTargetWidth:    DefaultContourMinTargetWidth,
+			MinTargetHeight:   DefaultContourMinTargetHeight,
+			MaxTargetWidth:    DefaultContourMaxTargetWidth,
+			MaxTargetHeight:   DefaultContourMaxTargetHeight,
+			FlatLineHeight:    DefaultContourFlatLineHeight,
+			ContainerHeight:   DefaultContourContainerHeight,
+			SameCenterSlack:   DefaultContourSameCenterSlack,
+			SquareIconSize:    DefaultContourSquareIconSize,
+			SquareIconSlack:   DefaultContourSquareIconSlack,
 		},
 
 		IncludeMenubarHints:           false,

--- a/internal/config/platform_support.go
+++ b/internal/config/platform_support.go
@@ -200,6 +200,21 @@ func PlatformSupport() parity.Declaration {
 			"hints.vision.image_min_size",
 			"hints.vision.checkbox_max_size",
 		),
+		// The contour detector is pure Go and every capture backend feeds it.
+		parity.Everywhere(parity.KindOption,
+			"hints.contour.request_timeout_ms",
+			"hints.contour.edge_low_threshold",
+			"hints.contour.edge_high_threshold",
+			"hints.contour.min_target_width",
+			"hints.contour.min_target_height",
+			"hints.contour.max_target_width",
+			"hints.contour.max_target_height",
+			"hints.contour.flat_line_height",
+			"hints.contour.container_height",
+			"hints.contour.same_center_slack",
+			"hints.contour.square_icon_size",
+			"hints.contour.square_icon_slack",
+		),
 		// Unbound modifier chords reach the focused application on macOS, on
 		// the Wayland evdev tap and on Windows. X11 cannot pass them through
 		// at all, which is a display-server limit rather than a column: the

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -563,3 +563,81 @@ func TestConfig_MouseActionAnimationScalesRejectNegatives(t *testing.T) {
 		t.Errorf("animation scales of 0 were rejected: %v", err)
 	}
 }
+
+// TestConfig_ContourBoundaries covers the default, a valid custom set, and
+// the rejected side of every hints.contour rule: the timeout, the ordered
+// Canny pair inside the Sobel range, the ordered target bounds, positive
+// dedup sizes, and flat lines shorter than containers.
+func TestConfig_ContourBoundaries(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*config.HintsContourConfig)
+		wantErr bool
+	}{
+		{name: "default", mutate: func(*config.HintsContourConfig) {}},
+		{name: "custom faint-edge profile", mutate: func(c *config.HintsContourConfig) {
+			c.EdgeLowThreshold = 30
+			c.EdgeHighThreshold = 90
+			c.MaxTargetHeight = 300
+		}},
+		{name: "low equal to high", mutate: func(c *config.HintsContourConfig) {
+			c.EdgeLowThreshold = 100
+			c.EdgeHighThreshold = 100
+		}},
+		{
+			name:    "zero timeout",
+			mutate:  func(c *config.HintsContourConfig) { c.RequestTimeoutMS = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "zero low threshold",
+			mutate:  func(c *config.HintsContourConfig) { c.EdgeLowThreshold = 0 },
+			wantErr: true,
+		},
+		{name: "low above high", mutate: func(c *config.HintsContourConfig) {
+			c.EdgeLowThreshold = 230
+		}, wantErr: true},
+		{name: "high above the sobel range", mutate: func(c *config.HintsContourConfig) {
+			c.EdgeHighThreshold = 1021
+		}, wantErr: true},
+		{name: "min width at max width", mutate: func(c *config.HintsContourConfig) {
+			c.MinTargetWidth = c.MaxTargetWidth
+		}, wantErr: true},
+		{
+			name:    "zero max height",
+			mutate:  func(c *config.HintsContourConfig) { c.MaxTargetHeight = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative same center slack",
+			mutate:  func(c *config.HintsContourConfig) { c.SameCenterSlack = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "zero square icon size",
+			mutate:  func(c *config.HintsContourConfig) { c.SquareIconSize = 0 },
+			wantErr: true,
+		},
+		{name: "flat line at container height", mutate: func(c *config.HintsContourConfig) {
+			c.FlatLineHeight = c.ContainerHeight
+		}, wantErr: true},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := validBase(t)
+			testCase.mutate(&cfg.Hints.Contour)
+
+			err := cfg.ValidateHints(nil)
+			if testCase.wantErr {
+				assertRejected(t, err, "hints.contour", testCase.name)
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("hints.contour %s was rejected: %v", testCase.name, err)
+			}
+		})
+	}
+}

--- a/internal/config/validators_boundary_test.go
+++ b/internal/config/validators_boundary_test.go
@@ -598,7 +598,7 @@ func TestConfig_ContourBoundaries(t *testing.T) {
 			c.EdgeLowThreshold = 230
 		}, wantErr: true},
 		{name: "high above the sobel range", mutate: func(c *config.HintsContourConfig) {
-			c.EdgeHighThreshold = 1021
+			c.EdgeHighThreshold = 1531
 		}, wantErr: true},
 		{name: "min width at max width", mutate: func(c *config.HintsContourConfig) {
 			c.MinTargetWidth = c.MaxTargetWidth

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -131,6 +131,7 @@ func (c *Config) ValidateHints(warnings *Warnings) error {
 		c.validateHintMissionControl,
 		c.validateHintVocabulary,
 		func() error { return validateHintsVisionConfig(c.Hints.Vision) },
+		func() error { return validateHintsContourConfig(c.Hints.Contour) },
 	}
 
 	for _, check := range checks {
@@ -571,6 +572,63 @@ func validateHintsVisionConfig(vision HintsVisionConfig) error {
 		return derrors.New(
 			derrors.CodeInvalidConfig,
 			"hints.vision.link_min_aspect must be greater than 0",
+		)
+	}
+
+	return nil
+}
+
+// validateHintsContourConfig checks the contour detector's numbers. Sizes
+// are positive, min/max pairs are ordered, and the Canny thresholds fit a
+// 0..255 luma gradient with low at or below high.
+func validateHintsContourConfig(contour HintsContourConfig) error {
+	if contour.RequestTimeoutMS <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.contour.request_timeout_ms must be greater than 0",
+		)
+	}
+
+	const maxGradient = 255 * 4 // Sobel |gx|+|gy| on a 0..255 frame
+
+	if contour.EdgeLowThreshold <= 0 || contour.EdgeHighThreshold > maxGradient ||
+		contour.EdgeLowThreshold > contour.EdgeHighThreshold {
+		return derrors.Newf(
+			derrors.CodeInvalidConfig,
+			"hints.contour edge thresholds must be > 0, at most %d, and low <= high",
+			maxGradient,
+		)
+	}
+
+	if contour.MinTargetWidth <= 0 || contour.MaxTargetWidth <= 0 ||
+		contour.MinTargetWidth >= contour.MaxTargetWidth {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.contour target width limits must be > 0 and min < max",
+		)
+	}
+
+	if contour.MinTargetHeight <= 0 || contour.MaxTargetHeight <= 0 ||
+		contour.MinTargetHeight >= contour.MaxTargetHeight {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.contour target height limits must be > 0 and min < max",
+		)
+	}
+
+	if contour.FlatLineHeight <= 0 || contour.ContainerHeight <= 0 ||
+		contour.SameCenterSlack <= 0 || contour.SquareIconSize <= 0 ||
+		contour.SquareIconSlack <= 0 {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.contour size thresholds must be greater than 0",
+		)
+	}
+
+	if contour.FlatLineHeight >= contour.ContainerHeight {
+		return derrors.New(
+			derrors.CodeInvalidConfig,
+			"hints.contour.flat_line_height must be less than container_height",
 		)
 	}
 

--- a/internal/config/validators_hints.go
+++ b/internal/config/validators_hints.go
@@ -589,7 +589,9 @@ func validateHintsContourConfig(contour HintsContourConfig) error {
 		)
 	}
 
-	const maxGradient = 255 * 4 // Sobel |gx|+|gy| on a 0..255 frame
+	// Sobel |gx|+|gy| peaks at 6*255 on a 0..255 frame: the two kernels
+	// share three positive and three negative taps, each weighted twice.
+	const maxGradient = 255 * 6
 
 	if contour.EdgeLowThreshold <= 0 || contour.EdgeHighThreshold > maxGradient ||
 		contour.EdgeLowThreshold > contour.EdgeHighThreshold {

--- a/internal/ports/mocks/vision.go
+++ b/internal/ports/mocks/vision.go
@@ -24,7 +24,7 @@ type MockVisionPort struct {
 		bool,
 	) ([]*element.Element, error)
 	CaptureScreenFunc  func(context.Context) (*image.RGBA, error)
-	DetectContoursFunc func(context.Context, image.Rectangle) ([]*element.Element, error)
+	DetectContoursFunc func(context.Context, image.Rectangle, config.HintsContourConfig) ([]*element.Element, error)
 
 	mu       sync.Mutex
 	detectN  int
@@ -76,13 +76,14 @@ func (m *MockVisionPort) CaptureScreen(ctx context.Context) (*image.RGBA, error)
 func (m *MockVisionPort) DetectContours(
 	ctx context.Context,
 	screenBounds image.Rectangle,
+	cfg config.HintsContourConfig,
 ) ([]*element.Element, error) {
 	m.mu.Lock()
 	m.contourN++
 	m.mu.Unlock()
 
 	if m.DetectContoursFunc != nil {
-		return m.DetectContoursFunc(ctx, screenBounds)
+		return m.DetectContoursFunc(ctx, screenBounds, cfg)
 	}
 
 	return nil, derrors.New(

--- a/internal/ports/vision.go
+++ b/internal/ports/vision.go
@@ -34,10 +34,12 @@ type VisionPort interface {
 
 	// DetectContours captures screenBounds and returns the interactive targets
 	// the contour detector (ported from wl-kbptr) finds in it, as clickable
-	// vision-only buttons with no title.
+	// vision-only buttons with no title. cfg tunes the detector. The caller
+	// bounds the pass with ctx.
 	DetectContours(
 		ctx context.Context,
 		screenBounds image.Rectangle,
+		cfg config.HintsContourConfig,
 	) ([]*element.Element, error)
 
 	// CaptureScreen returns the current screen image. Which screen "current"


### PR DESCRIPTION
## Description

This PR makes the `contour` hint strategy tunable. Until now it ran on the fixed numbers, so a user on a low-contrast theme, or one who wanted notification cards and toasts hinted, had no way to adjust what the detector picked up.

Every threshold the detector uses now comes from a new `[hints.contour]` section, and one contour pass has a time budget so a slow frame gives up instead of drawing a late overlay. The defaults are the values the detector already used, so nothing changes for a config that does not write the section.

### Config changes

New section, read on macOS, Linux and Windows alike. Existing configs keep working unchanged.

```toml
[hints.contour]
request_timeout_ms = 2000     # time budget for one pass
edge_low_threshold = 70       # Canny hysteresis low (Sobel magnitude, 0..255 luma)
edge_high_threshold = 220     # Canny hysteresis high; lower finds fainter outlines
min_target_width = 7.0        # logical px; smaller blobs are noise
min_target_height = 3.0
max_target_width = 650.0      # logical px; larger blobs are layout
max_target_height = 160.0
flat_line_height = 6.0        # nested strokes this short are dropped
container_height = 50.0       # blobs this tall are cards or dialogs
same_center_slack = 8.0       # nested blob near its parent's centre is a duplicate
square_icon_size = 40.0       # square parents under this drop inner detail
square_icon_slack = 5.0
```

Validation rejects a non-positive timeout, edge thresholds that are zero, above the Sobel range, or with low above high, a min at or above its max, non-positive sizes, and a flat line height at or above the container height.

## Related Issues

Closes #1649

## Target Platform

- [x] Platform-agnostic (shared logic, no OS-specific code)
- [x] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, the existing stub only gained the new parameter
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Additional Context

The timeout default is 2000ms rather than the 5000ms `hints.vision` uses because a contour pass takes a few milliseconds on a window and stays well under that on a full display. The detector checks the deadline between its expensive stages, so a cancelled pass returns promptly with no elements.

The dilation kernel, blur kernel and luma weights stay fixed. They interact with every option above and have no intuitive meaning to a user, so they were left as algorithm internals.

`just lint-cross` was also run for the Linux and Windows build tags.
