### PR TITLE
fix(linux): name mode chords with the activation modifier still held

### DIFF
--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -408,6 +408,51 @@ func TestEvdevProxy_MatchesTheChordEveryTime(t *testing.T) {
 	}
 }
 
+// The activation modifier held on two keyboards is one key down to the
+// compositor until the last of them lets go, and the session names chords with
+// it and holds sticky arming for exactly that long.
+func TestEvdevProxy_SessionKeepsTheChordModifierHeldOnAnotherKeyboard(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+	tap, keys := collectKeys(t)
+	tap.SetStickyModifierToggle(true)
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+	session := beginSession(proxy, tap)
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValueRelease))
+
+	if !session.forwardedModifiers[evdevKeyLeftMeta] {
+		t.Fatal("the chord's modifier was dropped while another keyboard still holds it")
+	}
+
+	if tap.stickyDetectionArmed() {
+		t.Fatal("sticky detection armed while another keyboard still holds the chord's modifier")
+	}
+
+	proxy.handle(keyEvent(evdevKeyA, evdevValuePress))
+
+	if got := nextKey(t, keys); got != "Cmd+a" {
+		t.Fatalf("dispatched %q with the modifier still held elsewhere, want %q", got, "Cmd+a")
+	}
+
+	proxy.handle(keyEvent(evdevKeyA, evdevValueRelease))
+	nextKey(t, keys) // the key-up event
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValueRelease))
+	noKey(t, keys)
+
+	if len(session.forwardedModifiers) != 0 {
+		t.Error("the chord's modifier is still counted after its last release")
+	}
+
+	if !tap.stickyDetectionArmed() {
+		t.Error("sticky detection did not arm once the last keyboard let go")
+	}
+}
+
 // A mode that starts under its activation chord does not wait for the chord to
 // come up. A key pressed under it carries the chord's modifier, as on macOS and
 // X11. The chord's modifier release goes to the compositor and is not a sticky

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -408,10 +408,11 @@ func TestEvdevProxy_MatchesTheChordEveryTime(t *testing.T) {
 	}
 }
 
-// A mode that starts under its activation chord neither waits for the chord to
-// come up nor reads it: the label typed while Super is still down is the label.
-// The chord's modifier release goes to the compositor and is not a sticky
-// toggle, and sticky detection arms once the chord has come up.
+// A mode that starts under its activation chord does not wait for the chord to
+// come up. A key pressed under it carries the chord's modifier, as on macOS and
+// X11. The chord's modifier release goes to the compositor and is not a sticky
+// toggle. Sticky detection arms once the chord has come up, and a key pressed
+// after that is the bare key.
 func TestEvdevProxy_SessionStartsUnderTheChordWithoutCountingIt(t *testing.T) {
 	t.Parallel()
 
@@ -429,16 +430,25 @@ func TestEvdevProxy_SessionStartsUnderTheChordWithoutCountingIt(t *testing.T) {
 
 	proxy.handle(keyEvent(evdevKeyA, evdevValuePress))
 
-	if got := nextKey(t, keys); got != "a" {
-		t.Fatalf("dispatched %q under the held activation modifier, want %q", got, "a")
+	if got := nextKey(t, keys); got != "Cmd+a" {
+		t.Fatalf("dispatched %q under the held activation modifier, want %q", got, "Cmd+a")
 	}
 
 	if proxy.rule.isDown(evdevKeyA) {
 		t.Error("a press during the session was forwarded to the compositor")
 	}
 
+	proxy.handle(keyEvent(evdevKeyA, evdevValueRelease))
+	nextKey(t, keys) // the key-up event
+
 	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValueRelease))
 	noKey(t, keys)
+
+	proxy.handle(keyEvent(evdevKeyA, evdevValuePress))
+
+	if got := nextKey(t, keys); got != "a" {
+		t.Fatalf("dispatched %q once the activation chord came up, want %q", got, "a")
+	}
 
 	if len(session.forwardedModifiers) != 0 {
 		t.Error("the chord's modifier is still counted after its release")

--- a/internal/adapter/eventtap/linux/evdev_session_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_session_cgo.go
@@ -18,11 +18,13 @@ import (
 //
 // It keeps its own picture of the modifiers, counting only presses the proxy
 // withheld for it. A modifier that was already down when the session began —
-// the activation chord's — was forwarded, so the compositor owns its release,
-// and the mode never sees it: a hint label typed while Super is still coming
-// up is the label, not Super plus the label. That is also what re-arms sticky
-// detection cleanly: the session starts at a clean slate of its own and waits
-// only for the chord to finish coming up.
+// the activation chord's — was forwarded, so the compositor owns its release
+// and the mode never sees it as a sticky toggle. It still names chords while
+// it is down. The macOS tap reads it off every event's flags and the X11 tap
+// counts it from the keyboard state after the grab, so Alt held from the
+// activation chord and Space pressed again is Alt+Space on every platform.
+// Sticky detection arms once the chord has finished coming up, and the
+// session's own count starts at a clean slate.
 type evdevSession struct {
 	tap   *EventTap
 	proxy *evdevProxy
@@ -152,7 +154,12 @@ func (s *evdevSession) chordName(code uint16) string {
 		return ""
 	}
 
-	return keyvocab.NormalizeKey(s.state.modifiers.prefix() + key)
+	held := s.state.modifiers.linuxModifierState
+	for forwarded := range s.forwardedModifiers {
+		held.update(s.proxy.capture.modifierName(forwarded), true)
+	}
+
+	return keyvocab.NormalizeKey(held.prefix() + key)
 }
 
 func (s *evdevSession) dispatchStickyToggle(modifier string, isDown bool) {

--- a/internal/adapter/eventtap/linux/evdev_session_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_session_cgo.go
@@ -116,11 +116,15 @@ func (s *evdevSession) handleRepeat(code uint16, modifier string, forwarded bool
 	s.tap.dispatchKey(chord)
 }
 
-func (s *evdevSession) handleRelease(code uint16, modifier string, _ bool) {
+func (s *evdevSession) handleRelease(code uint16, modifier string, forwarded bool) {
 	if modifier != "" {
 		if s.forwardedModifiers[code] {
-			delete(s.forwardedModifiers, code)
-			s.armIfClear()
+			// The compositor sees the key up only when the last keyboard
+			// holding it lets go, which is the release the rule forwards.
+			if forwarded {
+				delete(s.forwardedModifiers, code)
+				s.armIfClear()
+			}
 
 			return
 		}


### PR DESCRIPTION
## Description

This PR fixes mode chords on Wayland when the activation hotkey's modifier is still held.

Before, opening a mode with a chord such as `Alt+Space` and pressing `Space` again before letting go of `Alt` dispatched a bare `Space` to the mode. A `[recursive_grid.hotkeys]` binding on `"Alt+Space"` could never match on Hyprland or any other evdev-proxy Wayland session, while the same config worked on macOS and X11.

The evdev session now names a chord with every modifier down, including the activation chord's, which the compositor owns and the session never counted. Sticky-modifier detection is unchanged: those forwarded modifiers still never dispatch a toggle, and arming still waits for the chord to come up.

One behaviour that follows from this, and already holds on macOS and X11: with `passthrough_unbounded_keys = true`, an unbound key pressed while the activation modifier is still down now passes through to the focused app as the modified chord instead of being consumed. A hint label typed before the modifier is fully released will not match, exactly as on the other two platforms.

## Related Issues

Reported by a Hyprland user with a config binding `"Alt+Space" = ["action left_click", "recursive_grid"]` in both `[hotkeys]` and `[recursive_grid.hotkeys]`.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — none needed, the change is inside the existing `linux && cgo` session
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — the docs never stated the old rule
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## How to test

1. On a Wayland session using the evdev proxy, bind `"Alt+Space" = "recursive_grid"` under `[hotkeys]` and `"Alt+Space" = ["action left_click", "idle"]` under `[recursive_grid.hotkeys]`.
2. Press `Alt+Space`, keep `Alt` held, press `Space` again. The mode clicks and exits.
3. Release `Alt`, reopen the mode, press `Space` alone. The plain `"Space"` binding fires.
4. `go test ./internal/adapter/eventtap/linux/ -run SessionStartsUnderTheChord` covers both cases.
