### PR TITLE
fix(linux): make a hotkey click on Wayland land where the cursor is, unmodified

### DIFF
--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -171,7 +171,7 @@ answer.
 | **Keymap learns the focused app** | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher | ✅ published by the watcher |
 | **Cursor position**           | ✅ `CGEventGetLocation`  | ✅ `XQueryPointer`     | ✅ `hyprctl` on Hyprland, else sync-surface cache | ✅ sync-surface cache | ✅ `GetCursorPos` |
 | **Cursor move**               | ✅ `CGEventPost` ([`postMouseMoveLocked`](../internal/adapter/platform/darwin/accessibility_mouse_darwin.m)) | ✅ XTest (`XTestFakeMotionEvent`) | ✅ `zwlr_virtual_pointer` | ✅ libei                | ✅ `SetCursorPos`            |
-| **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest ⁷             | ✅ `zwlr_virtual_pointer`    | ✅ libei                | ✅ `SendInput` ⁷             |
+| **Mouse buttons / drag**      | ✅ `CGEventPost`         | ✅ XTest ⁷             | ✅ `zwlr_virtual_pointer` ⁷  | ✅ libei ⁷              | ✅ `SendInput` ⁷             |
 | **Scroll injection**          | ✅ both axes             | ✅ both axes ⁷         | ✅ both axes (uinput, virtual-pointer fallback) | ✅ both axes (uinput, libei fallback) | ✅ both axes ⁷               |
 | **Modified scroll (`--modifier`)** | ✅ `CGEventSetFlags` on every chunk | ✅ XTest key hold ⁷ | ✅ virtual keyboard + virtual pointer (uinput on Hyprland ⁹) | ✅ libei | ✅ `SendInput` key hold ⁷ |
 | **Smooth cursor animation**   | ✅ (incl. relative, opt-in) | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in | ✅ incl. relative, opt-in |
@@ -263,14 +263,22 @@ account's languages, reports no per-word confidence (so the three
 which Neru downsamples to and scales back from. Recognized text is screen
 content: never logged, never written to disk.
 
-⁷ **Modifiers on injected input (X11 and Windows).** An X11 pointer event and a
-`SendInput` mouse event both carry whatever modifiers the keyboard currently
-holds, so a hotkey chord still held while a hint was chosen used to make the
-click a ctrl+click. Neru reads the live key state (`XQueryKeymap`,
-`GetAsyncKeyState`), releases the modifiers the injection would falsify,
-presses the ones asked for, and undoes both when done, held across every chunk
-of an animated scroll and across a drag until its release. Restoring is the
-deliberate bias, since the opposite drops a modifier the user is still holding.
+⁷ **Modifiers on injected input (X11, Wayland and Windows).** An X11 pointer
+event, a Wayland pointer event and a `SendInput` mouse event all carry whatever
+modifiers the keyboard currently holds, so a hotkey chord still held while a
+hint was chosen used to make the click a ctrl+click, and a global `Alt+Space`
+bound to `action left_click` an alt+click. Neru reads the live key state
+(`XQueryKeymap`, `GetAsyncKeyState`), releases the modifiers the injection
+would falsify, presses the ones asked for, and undoes both when done, held
+across every chunk of an animated scroll and across a drag until its release.
+Restoring is the deliberate bias, since the opposite drops a modifier the user
+is still holding. On Wayland the keyboard the compositor reads is the evdev
+proxy's, so the proxy does the releasing and re-pressing
+(`LiftHeldModifiers` / `RestoreLiftedModifiers`), and only around a button
+event. A Wayland scroll still goes out beside the physically held modifiers.
+Without a forwarding proxy (no `/dev/uinput`, or the wl-keyboard fallback)
+there is nothing to lift, since the compositor reads the physical keyboards
+itself, and the click stays modified.
 
 ⁸ **Tray and notifications.** The tray icon carries the paused state on every
 platform: macOS swaps template glyphs, SNI hosts and the Win32 notification

--- a/internal/adapter/accessibility/native/linux/element.go
+++ b/internal/adapter/accessibility/native/linux/element.go
@@ -802,7 +802,19 @@ func pressWaylandModifiers(modifiers action.Modifiers) (action.Modifiers, error)
 // reported, reporting the first failure and letting go of the rest regardless:
 // stopping at the first error would leave the modifiers after it held.
 func releaseWaylandModifiers(pressed action.Modifiers) error {
-	var firstErr error
+	_, err := releaseWaylandModifiersRemaining(pressed)
+
+	return err
+}
+
+// releaseWaylandModifiersRemaining is releaseWaylandModifiers reporting the
+// modifiers still held because their release failed, for a caller that keeps
+// a record to retry from.
+func releaseWaylandModifiersRemaining(pressed action.Modifiers) (action.Modifiers, error) {
+	var (
+		firstErr  error
+		remaining action.Modifiers
+	)
 
 	for _, key := range slices.Backward(waylandModifierKeys) {
 		if !pressed.Has(key.modifier) {
@@ -810,12 +822,16 @@ func releaseWaylandModifiers(pressed action.Modifiers) error {
 		}
 
 		err := waylandModifierEvent(key.name, false)
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if err != nil {
+			remaining |= key.modifier
+
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 
-	return firstErr
+	return remaining, firstErr
 }
 
 // CurrentCursorPosition returns the cursor position.

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -185,43 +185,52 @@ func wlrootsMouseUpAtPoint(
 ) error {
 	heldModifiers, hadMouseDown := globalWlrootsPointerState.DownModifiers(button)
 	if hadMouseDown {
-		modifiers = heldModifiers
-	} else {
-		// A release with no press behind it is its own pointer action, so
-		// it lifts and restores around itself the way a click does.
-		restore := liftPhysicalModifiers()
-		defer restore()
+		return wlrootsReleaseHeldButton(point, button, heldModifiers)
+	}
 
-		err := wlrootsPressModifiers(modifiers)
-		if err != nil {
-			return err
-		}
+	// A release with no press behind it is its own pointer action, so it
+	// lifts and restores around itself the way a click does.
+	restore := liftPhysicalModifiers()
+	defer restore()
+
+	err := wlrootsPressModifiers(modifiers)
+	if err != nil {
+		return err
 	}
 
 	defer func() {
 		_ = wlrootsReleaseModifiers(modifiers)
 	}()
 
+	return linux.WaylandButtonEvent(point, wlrootsButton(button), false)
+}
+
+// wlrootsReleaseHeldButton ends a press this process recorded, letting go of
+// the modifiers it pressed. A failed release keeps the button recorded for the
+// idle cleanup to retry, naming only the modifiers whose release also failed:
+// the rest are up already, and a second release of a modifier Neru no longer
+// holds lets go of the user's own.
+func wlrootsReleaseHeldButton(
+	point image.Point,
+	button action.MouseButton,
+	modifiers action.Modifiers,
+) error {
 	err := linux.WaylandButtonEvent(point, wlrootsButton(button), false)
 	if err != nil {
-		if hadMouseDown {
-			// The deferred release above lets go of the press's modifiers,
-			// so the record the idle cleanup retries from must not name
-			// them again: a second release of a modifier Neru no longer
-			// holds lets go of the user's own.
-			if position, ok := globalWlrootsPointerState.DownPosition(button); ok {
-				globalWlrootsPointerState.SetDown(button, position, 0)
-			}
+		remaining, _ := releaseWaylandModifiersRemaining(modifiers)
 
-			restoreUnlessOtherHeld(button)
+		if position, ok := globalWlrootsPointerState.DownPosition(button); ok {
+			globalWlrootsPointerState.SetDown(button, position, remaining)
 		}
+
+		restoreUnlessOtherHeld(button)
 
 		return err
 	}
 
-	if hadMouseDown {
-		restoreAfterRelease(button)
-	}
+	_ = wlrootsReleaseModifiers(modifiers)
+
+	restoreAfterRelease(button)
 
 	return nil
 }

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"os"
 
+	eventtaplinux "github.com/y3owk1n/neru/internal/adapter/eventtap/linux"
 	"github.com/y3owk1n/neru/internal/adapter/platform"
 	"github.com/y3owk1n/neru/internal/adapter/platform/linux"
 	"github.com/y3owk1n/neru/internal/adapter/platform/mousestate"
@@ -93,11 +94,44 @@ func wlrootsButton(button action.MouseButton) int {
 	}
 }
 
+// liftPhysicalModifiers releases the modifiers the user's hand is on for the
+// length of a pointer action, so the action carries only the set it names.
+// This is the x11ClickButtonAtPoint rule applied to the one keyboard the
+// compositor reads here, the evdev proxy's (footnote 7 of
+// docs/CROSS_PLATFORM.md). The releases go out on uinput and the action on the
+// Wayland socket, and nothing orders the two, so a lift waits the fixed period
+// the uinput side always waits (waitForScrollDelivery). The returned restore
+// presses the lifted modifiers again once the compositor has processed the
+// action. WaylandSyncModifiers is the barrier for that.
+func liftPhysicalModifiers() func() {
+	lifted, err := eventtaplinux.LiftHeldModifiers()
+	if err != nil || !lifted {
+		return func() {}
+	}
+
+	waitForScrollDelivery()
+
+	return restorePhysicalModifiers
+}
+
+// restorePhysicalModifiers puts back the lifted modifiers once the compositor
+// has processed the action, or the release that ends a drag.
+func restorePhysicalModifiers() {
+	if !linux.WaylandSyncModifiers(modifierSyncTimeout) {
+		waitForScrollDelivery()
+	}
+
+	_ = eventtaplinux.RestoreLiftedModifiers()
+}
+
 func wlrootsMouseDownAtPoint(
 	point image.Point,
 	button action.MouseButton,
 	modifiers action.Modifiers,
 ) error {
+	// Lifted for the whole drag, as on X11: restored by the release.
+	_ = liftPhysicalModifiers()
+
 	err := wlrootsPressModifiers(modifiers)
 	if err != nil {
 		return err
@@ -132,6 +166,8 @@ func wlrootsMouseUpAtPoint(
 
 	defer func() {
 		_ = wlrootsReleaseModifiers(modifiers)
+
+		restorePhysicalModifiers()
 	}()
 
 	err := linux.WaylandButtonEvent(point, wlrootsButton(button), false)
@@ -151,6 +187,9 @@ func wlrootsClickButtonAtPoint(
 	button int,
 ) error {
 	original := wlrootsCurrentCursorPosition()
+
+	restore := liftPhysicalModifiers()
+	defer restore()
 
 	err := wlrootsPressModifiers(modifiers)
 	if err != nil {
@@ -202,6 +241,7 @@ func wlrootsMouseUp(button action.MouseButton) error {
 		_ = wlrootsReleaseModifiers(modifiers)
 	}
 
+	restorePhysicalModifiers()
 	globalWlrootsPointerState.Clear(button)
 
 	return nil

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -129,11 +129,15 @@ func wlrootsMouseDownAtPoint(
 	button action.MouseButton,
 	modifiers action.Modifiers,
 ) error {
-	// Lifted for the whole drag, as on X11: restored by the release.
-	_ = liftPhysicalModifiers()
+	// Lifted for the whole drag, as on X11: the release that ends the last
+	// held button restores. A press that fails restores here, since no
+	// release is coming for it.
+	restore := liftPhysicalModifiers()
 
 	err := wlrootsPressModifiers(modifiers)
 	if err != nil {
+		restore()
+
 		return err
 	}
 
@@ -141,12 +145,25 @@ func wlrootsMouseDownAtPoint(
 	if err != nil {
 		_ = wlrootsReleaseModifiers(modifiers)
 
+		restore()
+
 		return err
 	}
 
 	globalWlrootsPointerState.SetDown(button, point, modifiers)
 
 	return nil
+}
+
+// restoreAfterRelease puts the lifted modifiers back once the button just
+// released was the last one held, so a release of an unrelated button does
+// not re-modify a drag still in progress.
+func restoreAfterRelease(button action.MouseButton) {
+	globalWlrootsPointerState.Clear(button)
+
+	if !globalWlrootsPointerState.AnyDown() {
+		restorePhysicalModifiers()
+	}
 }
 
 func wlrootsMouseUpAtPoint(
@@ -158,6 +175,11 @@ func wlrootsMouseUpAtPoint(
 	if hadMouseDown {
 		modifiers = heldModifiers
 	} else {
+		// A release with no press behind it is its own pointer action, so
+		// it lifts and restores around itself the way a click does.
+		restore := liftPhysicalModifiers()
+		defer restore()
+
 		err := wlrootsPressModifiers(modifiers)
 		if err != nil {
 			return err
@@ -166,8 +188,6 @@ func wlrootsMouseUpAtPoint(
 
 	defer func() {
 		_ = wlrootsReleaseModifiers(modifiers)
-
-		restorePhysicalModifiers()
 	}()
 
 	err := linux.WaylandButtonEvent(point, wlrootsButton(button), false)
@@ -175,7 +195,9 @@ func wlrootsMouseUpAtPoint(
 		return err
 	}
 
-	globalWlrootsPointerState.Clear(button)
+	if hadMouseDown {
+		restoreAfterRelease(button)
+	}
 
 	return nil
 }
@@ -239,10 +261,9 @@ func wlrootsMouseUp(button action.MouseButton) error {
 
 	if hadMouseDown {
 		_ = wlrootsReleaseModifiers(modifiers)
-	}
 
-	restorePhysicalModifiers()
-	globalWlrootsPointerState.Clear(button)
+		restoreAfterRelease(button)
+	}
 
 	return nil
 }

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -205,6 +205,14 @@ func wlrootsMouseUpAtPoint(
 	err := linux.WaylandButtonEvent(point, wlrootsButton(button), false)
 	if err != nil {
 		if hadMouseDown {
+			// The deferred release above lets go of the press's modifiers,
+			// so the record the idle cleanup retries from must not name
+			// them again: a second release of a modifier Neru no longer
+			// holds lets go of the user's own.
+			if position, ok := globalWlrootsPointerState.DownPosition(button); ok {
+				globalWlrootsPointerState.SetDown(button, position, 0)
+			}
+
 			restoreUnlessOtherHeld(button)
 		}
 

--- a/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
+++ b/internal/adapter/accessibility/native/linux/element_wayland_wlroots_cgo.go
@@ -160,10 +160,22 @@ func wlrootsMouseDownAtPoint(
 // not re-modify a drag still in progress.
 func restoreAfterRelease(button action.MouseButton) {
 	globalWlrootsPointerState.Clear(button)
+	restoreUnlessOtherHeld(button)
+}
 
-	if !globalWlrootsPointerState.AnyDown() {
-		restorePhysicalModifiers()
+// restoreUnlessOtherHeld puts the lifted modifiers back unless a button other
+// than this one is still held. A release that failed goes through here with
+// its button still recorded, so the idle cleanup can retry it: the modifiers
+// come back regardless, which is the documented bias, since the opposite
+// drops a modifier the user is still holding.
+func restoreUnlessOtherHeld(button action.MouseButton) {
+	for _, held := range globalWlrootsPointerState.HeldButtons() {
+		if held != button {
+			return
+		}
 	}
+
+	restorePhysicalModifiers()
 }
 
 func wlrootsMouseUpAtPoint(
@@ -192,6 +204,10 @@ func wlrootsMouseUpAtPoint(
 
 	err := linux.WaylandButtonEvent(point, wlrootsButton(button), false)
 	if err != nil {
+		if hadMouseDown {
+			restoreUnlessOtherHeld(button)
+		}
+
 		return err
 	}
 
@@ -256,6 +272,10 @@ func wlrootsMouseUp(button action.MouseButton) error {
 
 	err := linux.WaylandButtonRelease(wlrootsButton(button))
 	if err != nil {
+		if hadMouseDown {
+			restoreUnlessOtherHeld(button)
+		}
+
 		return err
 	}
 

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -54,6 +54,13 @@ type evdevProxy struct {
 	global  waylandEvdevKeyState
 	session *evdevSession
 
+	// lifted is the modifiers the proxy has released on its keyboard while
+	// the user still holds them (liftHeldModifiers), so a synthetic pointer
+	// action does not pick them up. Their physical release is swallowed, as
+	// the compositor already has them up, and restoreLiftedModifiers presses
+	// the rest again.
+	lifted map[uint16]bool
+
 	// pointerFrame is whether the frame being read has put anything on the
 	// pointer proxy, so its sync report is sent there too.
 	pointerFrame bool
@@ -87,11 +94,14 @@ type evdevProxy struct {
 	done    chan struct{}
 }
 
-// proxyCommand replaces the current session (nil ends it). The run goroutine
-// closes ack once the replacement is in force, so the caller knows no event
-// will reach the old session after it returns.
+// proxyCommand replaces the current session (nil ends it). With run set it
+// runs that on the run goroutine instead. The run goroutine closes ack once
+// the replacement is in force or run has returned, so the caller knows no
+// event will reach the old session after it returns, and that run saw the
+// keyboard between two events.
 type proxyCommand struct {
 	session *evdevSession
+	run     func()
 	ack     chan struct{}
 }
 
@@ -184,6 +194,7 @@ func newEvdevProxy(logger *zap.Logger) (*evdevProxy, error) {
 		done:          make(chan struct{}),
 		heldByAnother: (*proxyNode).heldByAnother,
 		heldHotkeys:   make(map[uint16]func()),
+		lifted:        make(map[uint16]bool),
 		dispatch:      NewHotkeyDispatcher(),
 	}
 
@@ -295,6 +306,13 @@ func (p *evdevProxy) run() {
 	for {
 		select {
 		case cmd := <-p.control:
+			if cmd.run != nil {
+				cmd.run()
+				close(cmd.ack)
+
+				continue
+			}
+
 			p.session = cmd.session
 
 			if cmd.session != nil {
@@ -418,6 +436,9 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 
 		forwarded := p.rule.press(code, withhold)
 		if forwarded {
+			// A second keyboard pressing a lifted modifier puts it back
+			// down for the compositor, so it is lifted no longer.
+			delete(p.lifted, code)
 			p.emit(event)
 		} else if modifier == "" && !p.global.modifiers.allZero() {
 			p.cancelModifierShortcut()
@@ -428,7 +449,7 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 		}
 	case evdevValueRepeat:
 		forwarded := p.rule.repeat(code)
-		if forwarded {
+		if forwarded && !p.lifted[code] {
 			p.emit(event)
 		}
 
@@ -442,7 +463,12 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 
 		forwarded := p.rule.release(code)
 		if forwarded {
-			p.emit(event)
+			// The compositor already saw a lifted modifier go up.
+			if p.lifted[code] {
+				delete(p.lifted, code)
+			} else {
+				p.emit(event)
+			}
 		}
 
 		if p.session != nil {
@@ -700,6 +726,115 @@ func (p *evdevProxy) forwardWithheld(code uint16) {
 
 	p.rule.seed(code)
 	p.emitKey(code, evdevValuePress)
+}
+
+// liftHeldModifiers releases, on the proxy keyboard, every modifier the user
+// is physically holding that the compositor has down, and reports whether it
+// released any. A Wayland pointer event carries whatever modifiers the seat's
+// keyboards hold, not a set the sender chooses, so a hotkey chord still held
+// while a click is injected makes it a modified click. X11 and Windows fix
+// that from the live key state (footnote 7 of docs/CROSS_PLATFORM.md). On
+// Wayland only the proxy can, because its keyboard is the one the compositor
+// reads. Runs on the run goroutine.
+func (p *evdevProxy) liftHeldModifiers() bool {
+	held := make([]uint16, 0, len(p.global.pressed))
+
+	for pressed := range p.global.pressed {
+		if p.capture.modifierName(pressed) != "" && p.rule.isDown(pressed) && !p.lifted[pressed] {
+			held = append(held, pressed)
+		}
+	}
+
+	if len(held) == 0 {
+		return false
+	}
+
+	slices.Sort(held)
+
+	for _, code := range held {
+		p.lifted[code] = true
+		p.emitKey(code, evdevValueRelease)
+	}
+
+	return true
+}
+
+// restoreLiftedModifiers presses again the lifted modifiers the user is still
+// holding, so the keys they type next carry them as before. The re-press is
+// followed by the same symbol-less tap a withheld chord gets
+// (cancelModifierShortcut): a modifier pressed and then released alone is a
+// launcher shortcut on KWin, Mutter and a Hyprland release bind, and the click
+// between is not a key. Runs on the run goroutine.
+func (p *evdevProxy) restoreLiftedModifiers() {
+	if len(p.lifted) == 0 {
+		return
+	}
+
+	held := make([]uint16, 0, len(p.lifted))
+
+	for code := range p.lifted {
+		if p.rule.isDown(code) {
+			held = append(held, code)
+		}
+	}
+
+	clear(p.lifted)
+
+	if len(held) == 0 {
+		return
+	}
+
+	slices.Sort(held)
+
+	for _, code := range held {
+		p.emitKey(code, evdevValuePress)
+	}
+
+	p.cancelModifierShortcut()
+}
+
+// LiftHeldModifiers releases the modifiers the user is physically holding on
+// the proxy keyboard, so a pointer action injected next carries only the
+// modifiers it names, and reports whether any was released. Without a
+// forwarding proxy there is nothing to lift: the compositor reads the physical
+// keyboards itself. RestoreLiftedModifiers puts them back.
+func LiftHeldModifiers() (bool, error) {
+	proxy := currentEvdevProxy()
+	if proxy == nil || !proxy.forwarding.Load() {
+		return false, nil
+	}
+
+	var lifted bool
+
+	err := proxy.send(proxyCommand{
+		run: func() { lifted = proxy.liftHeldModifiers() },
+		ack: make(chan struct{}),
+	})
+
+	return lifted, err
+}
+
+// RestoreLiftedModifiers presses again the modifiers LiftHeldModifiers
+// released that the user still holds.
+func RestoreLiftedModifiers() error {
+	proxy := currentEvdevProxy()
+	if proxy == nil || !proxy.forwarding.Load() {
+		return nil
+	}
+
+	return proxy.send(proxyCommand{
+		run: proxy.restoreLiftedModifiers,
+		ack: make(chan struct{}),
+	})
+}
+
+// currentEvdevProxy returns the process-wide proxy if one has been built, and
+// never builds one: a pointer action is not a reason to grab the keyboards.
+func currentEvdevProxy() *evdevProxy {
+	sharedProxyMu.Lock()
+	defer sharedProxyMu.Unlock()
+
+	return sharedProxy
 }
 
 // ledLoop carries the compositor's LED changes, which land on the proxy

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -40,6 +40,7 @@ func newTestProxy() *evdevProxy {
 	empty := map[string]hotkeyBinding{}
 	proxy.bindings.Store(&empty)
 	proxy.heldHotkeys = make(map[uint16]func())
+	proxy.lifted = make(map[uint16]bool)
 	proxy.dispatch = NewHotkeyDispatcher()
 
 	return proxy
@@ -844,4 +845,128 @@ func TestGlobalHotkeyListener_StopDetachesTheBindings(t *testing.T) {
 	if listener.IsRunning() {
 		t.Error("the listener still reports itself running after Stop")
 	}
+}
+
+// A pointer action injected while the user holds a modifier would carry it,
+// so the proxy releases the held modifiers on its keyboard for the action and
+// presses them again after: the physical release in between is not re-emitted
+// (the compositor has the key up already), a modifier let go of during the
+// action is not pressed again, and the re-press is followed by the symbol-less
+// tap that keeps a modifier-alone shortcut from firing.
+func TestEvdevProxy_LiftsHeldModifiersAroundAPointerAction(t *testing.T) {
+	t.Parallel()
+
+	type emitted struct {
+		code  uint16
+		value int32
+	}
+
+	tests := []struct {
+		name          string
+		releaseDuring []uint16
+		wantRestore   []emitted
+		wantForwarded map[uint16]bool
+	}{
+		{
+			name: "both modifiers still held are pressed again",
+			wantRestore: []emitted{
+				{evdevKeyLeftAlt, evdevValuePress},
+				{evdevKeyLeftMeta, evdevValuePress},
+				{evdevKeyUnknown, evdevValuePress},
+				{evdevKeyUnknown, evdevValueRelease},
+			},
+			wantForwarded: map[uint16]bool{evdevKeyLeftAlt: true, evdevKeyLeftMeta: true},
+		},
+		{
+			name:          "a modifier let go of during the action stays up",
+			releaseDuring: []uint16{evdevKeyLeftMeta},
+			wantRestore: []emitted{
+				{evdevKeyLeftAlt, evdevValuePress},
+				{evdevKeyUnknown, evdevValuePress},
+				{evdevKeyUnknown, evdevValueRelease},
+			},
+			wantForwarded: map[uint16]bool{evdevKeyLeftAlt: true},
+		},
+		{
+			name:          "nothing held any more, nothing pressed again",
+			releaseDuring: []uint16{evdevKeyLeftAlt, evdevKeyLeftMeta},
+			wantRestore:   nil,
+			wantForwarded: map[uint16]bool{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			proxy := newTestProxy()
+
+			var got []emitted
+
+			proxy.emitted = func(code uint16, value int32) {
+				got = append(got, emitted{code, value})
+			}
+
+			proxy.handle(keyEvent(evdevKeyLeftAlt, evdevValuePress))
+			proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+
+			if !proxy.liftHeldModifiers() {
+				t.Fatal("nothing lifted with two modifiers held")
+			}
+
+			wantLift := []emitted{
+				{evdevKeyLeftAlt, evdevValueRelease},
+				{evdevKeyLeftMeta, evdevValueRelease},
+			}
+			if !slices.Equal(got, wantLift) {
+				t.Fatalf("lift emitted %v, want %v", got, wantLift)
+			}
+
+			if proxy.liftHeldModifiers() {
+				t.Fatal("a second lift released modifiers already lifted")
+			}
+
+			for _, code := range test.releaseDuring {
+				proxy.handle(keyEvent(code, evdevValueRelease))
+			}
+
+			got = nil
+
+			proxy.restoreLiftedModifiers()
+
+			if !slices.Equal(got, test.wantRestore) {
+				t.Fatalf("restore emitted %v, want %v", got, test.wantRestore)
+			}
+
+			for _, code := range []uint16{evdevKeyLeftAlt, evdevKeyLeftMeta} {
+				if proxy.rule.isDown(code) != test.wantForwarded[code] {
+					t.Errorf("key %d forwarded-down = %v after restore, want %v",
+						code, proxy.rule.isDown(code), test.wantForwarded[code])
+				}
+			}
+
+			if len(proxy.lifted) != 0 {
+				t.Errorf("%d modifiers still counted as lifted after restore", len(proxy.lifted))
+			}
+		})
+	}
+}
+
+// With no modifier held there is nothing to lift, and the proxy says so, so
+// the caller skips the wait it would otherwise give the release to land.
+func TestEvdevProxy_LiftsNothingWithNoModifierHeld(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+	proxy.emitted = func(code uint16, _ int32) {
+		t.Errorf("emitted key %d with nothing to lift", code)
+	}
+
+	proxy.handle(keyEvent(evdevKeyA, evdevValuePress))
+
+	if proxy.liftHeldModifiers() {
+		t.Fatal("lifted with no modifier held")
+	}
+
+	proxy.restoreLiftedModifiers()
 }

--- a/internal/adapter/eventtap/linux/tap_nocgo.go
+++ b/internal/adapter/eventtap/linux/tap_nocgo.go
@@ -53,12 +53,13 @@ func IsWaylandEvdevKeyboardActive() bool {
 	return false
 }
 
-// LiftHeldModifiers reports nothing lifted: the evdev proxy needs cgo.
+// LiftHeldModifiers reports that the evdev proxy is compiled out. The caller
+// degrades to a click that keeps the held modifiers.
 func LiftHeldModifiers() (bool, error) {
-	return false, nil
+	return false, errUinputScrollNoCGO("evdev proxy modifier lift")
 }
 
-// RestoreLiftedModifiers has nothing to restore: the evdev proxy needs cgo.
+// RestoreLiftedModifiers reports that the evdev proxy is compiled out.
 func RestoreLiftedModifiers() error {
-	return nil
+	return errUinputScrollNoCGO("evdev proxy modifier restore")
 }

--- a/internal/adapter/eventtap/linux/tap_nocgo.go
+++ b/internal/adapter/eventtap/linux/tap_nocgo.go
@@ -52,3 +52,13 @@ func IsUinputScrollAvailable() bool {
 func IsWaylandEvdevKeyboardActive() bool {
 	return false
 }
+
+// LiftHeldModifiers reports nothing lifted: the evdev proxy needs cgo.
+func LiftHeldModifiers() (bool, error) {
+	return false, nil
+}
+
+// RestoreLiftedModifiers has nothing to restore: the evdev proxy needs cgo.
+func RestoreLiftedModifiers() error {
+	return nil
+}

--- a/internal/app/services/action_service.go
+++ b/internal/app/services/action_service.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -263,16 +264,39 @@ func (s *ActionService) MoveMouseRelative(
 	return s.MoveMouseTo(ctx, cursorPos.X+deltaX, cursorPos.Y+deltaY, shouldBypass)
 }
 
+// cursorSyncTimeout bounds the cursor-cache refresh before an action, the same
+// budget modes give it on activation (modes.cursorSyncTimeout). A slow
+// compositor query degrades to the cached position rather than stalling the
+// action.
+const cursorSyncTimeout = 150 * time.Millisecond
+
 // CursorPositionForAction returns the cursor position for resolving an
 // action's target point. Unlike CursorPosition it first settles any in-flight
 // cursor animation (ports.CursorSettler), so an action fired mid-animation
-// acts at the point the user aimed for instead of a mid-animation position.
-// Plain observers that must not cut animations short use CursorPosition.
+// acts at the point the user aimed for instead of a mid-animation position,
+// and then refreshes the platform's cursor cache (ports.CursorSynchronizer):
+// on Wayland a hand-moved mouse invalidates that cache, and an action fired
+// from idle, where no mode activation has resynced it, would otherwise land on
+// the stale point. Plain observers that must not cut animations short use
+// CursorPosition.
 func (s *ActionService) CursorPositionForAction(ctx context.Context) (image.Point, error) {
 	if settler, ok := s.system.(ports.CursorSettler); ok {
 		err := settler.SettleCursor(ctx)
 		if err != nil {
 			s.logger.Warn("Failed to settle cursor animation", zap.Error(err))
+		}
+	}
+
+	if syncer, ok := s.system.(ports.CursorSynchronizer); ok {
+		syncCtx, cancel := context.WithTimeout(ctx, cursorSyncTimeout)
+		defer cancel()
+
+		err := syncer.SyncCursorPosition(syncCtx)
+		if err != nil {
+			s.logger.Warn(
+				"Failed to sync cursor position; action target may be stale",
+				zap.Error(err),
+			)
 		}
 	}
 

--- a/internal/app/services/action_service_test.go
+++ b/internal/app/services/action_service_test.go
@@ -492,3 +492,80 @@ func TestMoveMouseToCenterOfWindow_ReportsARealFailureAsAccessibilityFailure(t *
 			derrors.GetCode(err), derrors.CodeAccessibilityFailed)
 	}
 }
+
+// syncingSystemPort is a MockSystemPort that also implements
+// ports.CursorSynchronizer, standing in for the Wayland adapter whose cursor
+// cache a hand-moved mouse invalidates.
+type syncingSystemPort struct {
+	portmocks.MockSystemPort
+
+	synced  bool
+	syncErr error
+	// position is what CursorPosition reports; SyncCursorPosition moves it
+	// to physical, the way the adapter re-learns the real pointer.
+	position image.Point
+	physical image.Point
+}
+
+func (s *syncingSystemPort) SyncCursorPosition(ctx context.Context) error {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		return derrors.New(derrors.CodeInternal, "sync ran without a deadline")
+	}
+
+	s.synced = true
+
+	if s.syncErr != nil {
+		return s.syncErr
+	}
+
+	s.position = s.physical
+
+	return nil
+}
+
+// TestActionService_CursorPositionForAction_SyncsStaleCursorCache pins the
+// idle-hotkey click on Wayland: with no mode active nothing has refreshed the
+// adapter's cursor cache since the user moved the mouse by hand, so the action
+// must resync before it resolves its target point.
+func TestActionService_CursorPositionForAction_SyncsStaleCursorCache(t *testing.T) {
+	tests := []struct {
+		name    string
+		syncErr error
+		want    image.Point
+	}{
+		{name: "sync succeeds, physical position wins", want: image.Point{X: 300, Y: 400}},
+		{
+			name:    "sync fails, cached position still returned",
+			syncErr: derrors.New(derrors.CodeTimeout, "hyprctl"),
+			want:    image.Point{X: 10, Y: 20},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			sys := &syncingSystemPort{
+				syncErr:  testCase.syncErr,
+				position: image.Point{X: 10, Y: 20},
+				physical: image.Point{X: 300, Y: 400},
+			}
+			sys.CursorPositionFunc = func(context.Context) (image.Point, error) {
+				return sys.position, nil
+			}
+
+			svc := newTestActionService(&portmocks.MockAccessibilityPort{}, sys)
+
+			got, err := svc.CursorPositionForAction(context.Background())
+			if err != nil {
+				t.Fatalf("CursorPositionForAction() error = %v", err)
+			}
+
+			if !sys.synced {
+				t.Fatal("CursorPositionForAction() did not sync the cursor cache")
+			}
+
+			if got != testCase.want {
+				t.Errorf("CursorPositionForAction() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes `action left_click` fired from a global hotkey on Wayland. Two things went wrong on Hyprland with `"Alt+Space" = "action left_click"` and no mode active.

The click landed on a stale point. The Wayland adapter caches the cursor position, and only mode activation refreshed it, so moving the mouse by hand and then firing the hotkey clicked wherever the cache last pointed. Actions now resync the cache before resolving their target, under the same 150ms budget modes use. macOS and X11 query the OS directly and are unchanged.

The click arrived as alt+click. The evdev proxy withholds the chord's key but forwards its modifier, and a Wayland pointer event carries whatever the seat's keyboards hold. The proxy now releases the physically held modifiers on its uinput keyboard around a button event and presses them again afterwards, the same rule X11 and Windows already apply from the live key state (footnote 7 in `docs/CROSS_PLATFORM.md`). A physical release during the click is swallowed, and the re-press is followed by the symbol-less tap that keeps a modifier-alone launcher shortcut from firing. Without a forwarding proxy (no `/dev/uinput`, or the wl-keyboard fallback) nothing is lifted and the click stays modified, which the docs now state.

How to test on Hyprland: bind `"Alt+Space" = "action left_click"` under `[hotkeys]`, restart the daemon, move the mouse by hand, press Alt+Space. The click should land under the pointer with no Alt. Keep Alt held afterwards and press Tab: Alt+Tab should still work.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [ ] N/A — This PR does not touch platform-specific code

The nocgo stubs for `LiftHeldModifiers` / `RestoreLiftedModifiers` report nothing lifted rather than `CodeNotSupported`: the caller degrades to a modified click either way, and an error would abort the click.

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a conventional commit subject written for users

## Additional Context

The cursor resync costs one `hyprctl cursorpos` round trip per idle action on Hyprland, and a layer-shell discovery pass on Sway and niri. In-mode actions with a selection point never reach it. The modifier lift only runs when a modifier is physically held, so plain clicks pay nothing.
