### PR TITLE
fix(overlay): draw only hint labels and badges bold on Windows and Linux

### DIFF
--- a/internal/adapter/overlay/linux/corner_radius_test.go
+++ b/internal/adapter/overlay/linux/corner_radius_test.go
@@ -57,6 +57,7 @@ type recordedText struct {
 	center     image.Point
 	fontSize   float64
 	color      uint32
+	bold       bool
 }
 
 func (s *recordingSurface) alive() bool { return true }
@@ -114,7 +115,7 @@ func (s *recordingSurface) hintBadgePrim(
 
 func (s *recordingSurface) textPrim(
 	text, fontFamily string, centerX, centerY, fontSize float64, color uint32,
-	_ bool,
+	bold bool,
 ) {
 	s.texts = append(s.texts, recordedText{
 		text:       text,
@@ -122,6 +123,7 @@ func (s *recordingSurface) textPrim(
 		center:     image.Pt(int(centerX), int(centerY)),
 		fontSize:   fontSize,
 		color:      color,
+		bold:       bold,
 	})
 }
 

--- a/internal/adapter/overlay/linux/corner_radius_test.go
+++ b/internal/adapter/overlay/linux/corner_radius_test.go
@@ -114,6 +114,7 @@ func (s *recordingSurface) hintBadgePrim(
 
 func (s *recordingSurface) textPrim(
 	text, fontFamily string, centerX, centerY, fontSize float64, color uint32,
+	_ bool,
 ) {
 	s.texts = append(s.texts, recordedText{
 		text:       text,

--- a/internal/adapter/overlay/linux/font_weight_test.go
+++ b/internal/adapter/overlay/linux/font_weight_test.go
@@ -1,0 +1,93 @@
+//go:build linux && cgo
+
+package linux
+
+import (
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
+	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+)
+
+// The weight each surface draws at is the one macOS draws it at: hint labels
+// bold, everything else regular. Before this was pinned every Linux string was
+// bold, so a grid at the default 10 points read heavier than on macOS.
+
+func TestSharedOverlay_DrawHints_LabelsAreBold(t *testing.T) {
+	t.Parallel()
+
+	surface := &recordingSurface{scale: 1}
+	overlay := &sharedOverlay{srf: surface}
+
+	overlay.drawHints(
+		[]*hintscomponent.Hint{
+			hintscomponent.NewHint("ab", image.Pt(200, 200), image.Pt(40, 20), ""),
+		},
+		hintscomponent.BuildStyle(config.DefaultConfig().Hints, nil),
+		badge.HintOnTarget,
+	)
+
+	painted, found := surface.findText("ab")
+	if !found {
+		t.Fatalf("painted %v, want the hint label", surface.paintedStrings())
+	}
+
+	if !painted.bold {
+		t.Error("hint label drawn regular, want bold as on macOS")
+	}
+}
+
+func TestLinuxOverlayManager_DrawHintSearchInput_IsRegularWeight(t *testing.T) {
+	t.Parallel()
+
+	overlayManager, surface := recordingManager()
+
+	err := overlayManager.DrawHintSearchInput(
+		"sav", 3,
+		hintscomponent.NewSearchInputFrame(image.Pt(10, 20), 300),
+		searchStyle(false),
+	)
+	if err != nil {
+		t.Fatalf("DrawHintSearchInput() error = %v", err)
+	}
+
+	painted, found := surface.findText("/ sav  3")
+	if !found {
+		t.Fatalf("painted %v, want the query badge", surface.paintedStrings())
+	}
+
+	if painted.bold {
+		t.Error("search input drawn bold, want regular as on macOS")
+	}
+}
+
+func TestLinuxOverlayManager_DrawGrid_LabelsAreRegularWeight(t *testing.T) {
+	t.Parallel()
+
+	overlayManager, surface := recordingManager()
+
+	err := overlayManager.DrawGrid(
+		domainGrid.NewGrid("ab", image.Rect(0, 0, 800, 600), zap.NewNop()),
+		"",
+		gridcomponent.BuildStyle(config.DefaultConfig().Grid, fixedTheme(false)),
+	)
+	if err != nil {
+		t.Fatalf("DrawGrid() error = %v", err)
+	}
+
+	if len(surface.texts) == 0 {
+		t.Fatal("DrawGrid painted no labels")
+	}
+
+	for _, painted := range surface.texts {
+		if painted.bold {
+			t.Fatalf("grid label %q drawn bold, want regular as on macOS", painted.text)
+		}
+	}
+}

--- a/internal/adapter/overlay/linux/hint_search_test.go
+++ b/internal/adapter/overlay/linux/hint_search_test.go
@@ -245,7 +245,7 @@ func (s *silentSurface) hintBadgePrim(
 ) {
 }
 
-func (s *silentSurface) textPrim(_, _ string, _, _, _ float64, _ uint32) {}
+func (s *silentSurface) textPrim(_, _ string, _, _, _ float64, _ uint32, _ bool) {}
 
 // TestLinuxOverlayManager_HintSearchInputIsSerializedWithTheHintsDraw is the
 // -race regression for the screen state this feature added. searchBadgeRect on

--- a/internal/adapter/overlay/linux/overlay_shared_cgo.go
+++ b/internal/adapter/overlay/linux/overlay_shared_cgo.go
@@ -81,7 +81,7 @@ type overlaySurface interface {
 		badgeRect image.Rectangle, radius float64, edge int, arrow badge.HintArrow,
 		fill, border uint32, lineWidth float64,
 	)
-	textPrim(text, fontFamily string, centerX, centerY, fontSize float64, color uint32)
+	textPrim(text, fontFamily string, centerX, centerY, fontSize float64, color uint32, bold bool)
 }
 
 // sharedOverlay is the backend-independent half of a Linux overlay: all
@@ -629,7 +629,7 @@ func (o *sharedOverlay) drawBadge(
 	rect := badgeBounds(posX, posY, text, scaledStyle)
 
 	o.drawRect(rect, colors.background, colors.border, max(style.borderWidth, 1))
-	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text)
+	o.drawTextCentered(text, rect, style.fontFamily, fontSize, colors.text, true)
 }
 
 // drawMonitorSelect renders one centered, labeled panel per monitor for the
@@ -666,7 +666,14 @@ func (o *sharedOverlay) drawMonitorSelect(
 		)
 		o.drawRoundedRect(panel, radius, spec.background, spec.border, spec.borderWidth)
 
-		o.drawTextCentered(target.Label, labelRect, style.FontFamily, spec.labelFont, spec.text)
+		o.drawTextCentered(
+			target.Label,
+			labelRect,
+			style.FontFamily,
+			spec.labelFont,
+			spec.text,
+			true,
+		)
 
 		if target.Subtitle != "" {
 			// The subtitle family is never empty: an unset one is settled to
@@ -674,6 +681,7 @@ func (o *sharedOverlay) drawMonitorSelect(
 			o.drawTextCentered(
 				target.Subtitle, subtitleRect,
 				style.SubtitleFontFamily, spec.subtitleFont, spec.subtitleText,
+				false,
 			)
 		}
 	}
@@ -786,6 +794,7 @@ func (o *sharedOverlay) repaintHints(
 			style.FontFamily(),
 			fontSize,
 			badge.ParseHexARGB(textColor),
+			true,
 		)
 	}
 
@@ -840,6 +849,7 @@ func (o *sharedOverlay) drawHintSearchInput(
 		style.FontFamily(),
 		fontSize,
 		badge.ParseHexARGB(style.TextColor()),
+		false,
 	)
 
 	o.srf.surfaceFlush()
@@ -1226,6 +1236,7 @@ func (o *sharedOverlay) drawFrame(
 				o.drawTextCentered(
 					label, cell, style.FontFamily(),
 					style.LabelFontSize(), style.TextColorARGB(),
+					false,
 				)
 			}
 
@@ -1265,7 +1276,7 @@ func (o *sharedOverlay) drawVirtualPointer(vp recursivegridcomponent.VirtualPoin
 		vp.Position.Y+halfSize,
 	)
 	o.drawTextCentered(vpChar, vpBounds, fontName, fontSize,
-		badge.ParseHexARGB(vp.FillColor))
+		badge.ParseHexARGB(vp.FillColor), false)
 }
 
 // redrawGrid paints the grid surface as it currently stands, which is either
@@ -1323,7 +1334,7 @@ func (o *sharedOverlay) redrawGrid() {
 		cellBounds := o.offset(cell.Bounds())
 		o.drawRect(cellBounds, fill, border, style.LineWidth())
 		o.drawTextCentered(label, cellBounds,
-			style.FontFamily(), style.LabelFontSize(), text)
+			style.FontFamily(), style.LabelFontSize(), text, false)
 	}
 
 	o.paintGridPointer()
@@ -1356,6 +1367,7 @@ func (o *sharedOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.
 			style.FontFamily(),
 			style.LabelFontSize()*subgridFontScale,
 			style.TextColorARGB(),
+			false,
 		)
 	}
 }
@@ -1416,12 +1428,13 @@ func (o *sharedOverlay) drawHintBadge(
 func (o *sharedOverlay) drawTextCentered(
 	text string, bounds image.Rectangle,
 	fontFamily string, fontSize float64, color uint32,
+	bold bool,
 ) {
 	o.srf.textPrim(
 		text, fontFamily,
 		float64(bounds.Min.X+bounds.Dx()/2),
 		float64(bounds.Min.Y+bounds.Dy()/2),
-		fontSize*o.srf.surfaceScale(), color,
+		fontSize*o.srf.surfaceScale(), color, bold,
 	)
 }
 
@@ -1469,6 +1482,7 @@ func (o *sharedOverlay) drawSubKeyMiniGrid(
 			subCell.Label, subCell.Bounds,
 			style.FontFamily(), style.SubKeyPreviewFontSizeF(),
 			style.SubKeyPreviewTextColorARGB(),
+			false,
 		)
 	}
 }

--- a/internal/adapter/overlay/linux/shared_delegates_test.go
+++ b/internal/adapter/overlay/linux/shared_delegates_test.go
@@ -63,7 +63,7 @@ func (s *closedSurface) hintBadgePrim(
 	s.touched("hintBadgePrim")
 }
 
-func (s *closedSurface) textPrim(_, _ string, _, _, _ float64, _ uint32) {
+func (s *closedSurface) textPrim(_, _ string, _, _, _ float64, _ uint32, _ bool) {
 	s.touched("textPrim")
 }
 

--- a/internal/adapter/overlay/linux/wayland_cgo.go
+++ b/internal/adapter/overlay/linux/wayland_cgo.go
@@ -320,6 +320,7 @@ func (o *wlrootsOverlay) hintBadgePrim(
 func (o *wlrootsOverlay) textPrim(
 	text, fontFamily string,
 	centerX, centerY, fontSize float64, color uint32,
+	bold bool,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -327,10 +328,15 @@ func (o *wlrootsOverlay) textPrim(
 	defer C.free(unsafe.Pointer(cText))
 	defer C.free(unsafe.Pointer(cFontFamily))
 
+	cBold := C.int(0)
+	if bold {
+		cBold = 1
+	}
+
 	C.neru_wayland_overlay_text(
 		o.raw, cText, cFontFamily,
 		C.double(centerX),
 		C.double(centerY),
-		C.double(fontSize), C.uint(color),
+		C.double(fontSize), C.uint(color), cBold,
 	)
 }

--- a/internal/adapter/overlay/linux/x11_cgo.go
+++ b/internal/adapter/overlay/linux/x11_cgo.go
@@ -205,6 +205,7 @@ func (o *x11Overlay) hintBadgePrim(
 func (o *x11Overlay) textPrim(
 	text, fontFamily string,
 	centerX, centerY, fontSize float64, color uint32,
+	bold bool,
 ) {
 	cText := C.CString(text)
 	cFontFamily := C.CString(fontFamily)
@@ -212,10 +213,15 @@ func (o *x11Overlay) textPrim(
 	defer C.free(unsafe.Pointer(cText))
 	defer C.free(unsafe.Pointer(cFontFamily))
 
+	cBold := C.int(0)
+	if bold {
+		cBold = 1
+	}
+
 	C.neru_x11_overlay_text(
 		o.raw, cText, cFontFamily,
 		C.double(centerX),
 		C.double(centerY),
-		C.double(fontSize), C.uint(color),
+		C.double(fontSize), C.uint(color), cBold,
 	)
 }

--- a/internal/adapter/overlay/windows/features.go
+++ b/internal/adapter/overlay/windows/features.go
@@ -163,6 +163,7 @@ func (o *winOverlay) DrawHints(
 			style.FontFamily(),
 			fontSize,
 			badge.ParseHexARGB(textColor),
+			true,
 		)
 	}
 
@@ -344,6 +345,7 @@ func (o *winOverlay) paintRecursiveGrid(
 					style.FontFamily(),
 					style.LabelFontSize()*scale,
 					style.TextColorARGB(),
+					false,
 				)
 			}
 
@@ -449,6 +451,7 @@ func (o *winOverlay) drawSubKeyMiniGrid(
 			style.FontFamily(),
 			style.SubKeyPreviewFontSizeF()*o.scale(),
 			style.SubKeyPreviewTextColorARGB(),
+			false,
 		)
 	}
 }

--- a/internal/adapter/overlay/windows/font_weight_test.go
+++ b/internal/adapter/overlay/windows/font_weight_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package windows
+
+import (
+	"image"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/adapter/overlay/manager"
+	"github.com/y3owk1n/neru/internal/adapter/overlay/render/badge"
+	gridcomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/grid"
+	hintscomponent "github.com/y3owk1n/neru/internal/adapter/overlay/render/hints"
+	"github.com/y3owk1n/neru/internal/config"
+)
+
+// The weight each surface draws at is the one macOS draws it at: hint labels
+// bold, everything else regular. Before this was pinned every Windows string
+// was bold in both renderers, so a grid at the default 10 points read heavier
+// than on macOS.
+
+// boldOf reports how the last paint of text was weighted.
+func (w *recordingWindow) boldOf(text string) (bool, bool) {
+	index := slices.Index(w.texts, text)
+	if index < 0 {
+		return false, false
+	}
+
+	return w.bolds[index], true
+}
+
+func TestWinOverlay_DrawHints_LabelsAreBold(t *testing.T) {
+	t.Parallel()
+
+	window := &recordingWindow{}
+	overlay := &winOverlay{window: window, logger: zap.NewNop()}
+	style := hintscomponent.BuildStyle(config.DefaultConfig().Hints, fixedTheme(false))
+	hint := hintscomponent.NewHint("AB", image.Pt(400, 300), image.Pt(40, 20), "")
+
+	overlay.DrawHints([]*hintscomponent.Hint{hint}, style, badge.HintOnTarget)
+
+	bold, found := window.boldOf("AB")
+	if !found {
+		t.Fatalf("painted %v, want the hint label", window.texts)
+	}
+
+	if !bold {
+		t.Error("hint label drawn regular, want bold as on macOS")
+	}
+}
+
+func TestWindowsOverlayManager_DrawHintSearchInput_IsRegularWeight(t *testing.T) {
+	t.Parallel()
+
+	window := &recordingWindow{}
+	overlayManager := &Manager{Base: manager.NewBase(zap.NewNop())}
+	overlayManager.win = &winOverlay{window: window, renderMu: &overlayManager.renderMu}
+
+	err := overlayManager.DrawHintSearchInput(
+		"sav", 3,
+		hintscomponent.NewSearchInputFrame(image.Pt(10, 20), 300),
+		hintscomponent.BuildSearchInputStyle(config.DefaultConfig().Hints, fixedTheme(false)),
+	)
+	if err != nil {
+		t.Fatalf("DrawHintSearchInput() error = %v", err)
+	}
+
+	bold, found := window.boldOf("/ sav  3")
+	if !found {
+		t.Fatalf("painted %v, want the query badge", window.texts)
+	}
+
+	if bold {
+		t.Error("search input drawn bold, want regular as on macOS")
+	}
+}
+
+func TestWindowsOverlayManager_DrawGrid_LabelsAreRegularWeight(t *testing.T) {
+	t.Parallel()
+
+	window := &recordingWindow{}
+	overlayManager := &Manager{Base: manager.NewBase(zap.NewNop())}
+	overlayManager.win = &winOverlay{window: window, renderMu: &overlayManager.renderMu}
+
+	err := overlayManager.DrawGrid(
+		testGrid(), "",
+		gridcomponent.BuildStyle(config.DefaultConfig().Grid, fixedTheme(false)),
+	)
+	if err != nil {
+		t.Fatalf("DrawGrid() error = %v", err)
+	}
+
+	if len(window.texts) == 0 {
+		t.Fatal("DrawGrid painted no labels")
+	}
+
+	for index, bold := range window.bolds {
+		if bold {
+			t.Fatalf("grid label %q drawn bold, want regular as on macOS", window.texts[index])
+		}
+	}
+}

--- a/internal/adapter/overlay/windows/font_weight_test.go
+++ b/internal/adapter/overlay/windows/font_weight_test.go
@@ -67,12 +67,12 @@ func TestWindowsOverlayManager_DrawHintSearchInput_IsRegularWeight(t *testing.T)
 		t.Fatalf("DrawHintSearchInput() error = %v", err)
 	}
 
-	bold, found := window.boldOf("/ sav  3")
-	if !found {
-		t.Fatalf("painted %v, want the query badge", window.texts)
+	// The badge is the one string this draw paints, cursor included.
+	if len(window.texts) != 1 {
+		t.Fatalf("painted %v, want the query badge alone", window.texts)
 	}
 
-	if bold {
+	if window.bolds[0] {
 		t.Error("search input drawn bold, want regular as on macOS")
 	}
 }

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -414,6 +414,7 @@ func (m *Manager) DrawHintSearchInput(
 		style.FontFamily(),
 		fontSize,
 		badge.ParseHexARGB(style.TextColor()),
+		false,
 	)
 
 	m.win.flushOverlay("search-input")
@@ -547,6 +548,7 @@ func (m *Manager) DrawModeIndicator(cursorX, cursorY int) {
 		ports.ResolveFont(cfg.UI.FontFamily),
 		fontSize,
 		badge.ParseHexARGB(textColor),
+		true,
 	)
 
 	// Flush composites fills/strokes/texts into the pixel buffer and sends
@@ -658,6 +660,7 @@ func (m *Manager) DrawStickyModifiersIndicator(cursorX, cursorY int, symbols str
 		ports.ResolveFont(indicatorUI.FontFamily),
 		fontSize,
 		badge.ParseHexARGB(textColor),
+		true,
 	)
 
 	err := m.stickyWin.Flush()

--- a/internal/adapter/overlay/windows/monitor_select.go
+++ b/internal/adapter/overlay/windows/monitor_select.go
@@ -194,11 +194,12 @@ func (m *Manager) DrawMonitorSelect(
 			win.StrokeRoundedRect(panel, radius, border, borderWidth)
 		}
 
-		win.DrawTextCentered(target.Label, labelRect, style.FontFamily, labelFont, text)
+		win.DrawTextCentered(target.Label, labelRect, style.FontFamily, labelFont, text, true)
 
 		if target.Subtitle != "" {
 			win.DrawTextCentered(
 				target.Subtitle, subtitleRect, style.SubtitleFontFamily, subtitleFont, subtitleText,
+				false,
 			)
 		}
 

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -55,6 +55,7 @@ type overlayWindow interface {
 		fontFamily string,
 		fontSize float64,
 		color uint32,
+		bold bool,
 	)
 	DrawPointerGlyph(center image.Point, size int, char string, fontFamily string, color uint32)
 	Flush() error
@@ -539,6 +540,7 @@ func (o *winOverlay) drawGridCells() {
 				style.FontFamily(),
 				style.LabelFontSize()*scale,
 				text,
+				false,
 			)
 		}
 	}
@@ -590,6 +592,7 @@ func (o *winOverlay) drawSubgrid(bounds image.Rectangle, style gridcomponent.Sty
 			style.FontFamily(),
 			style.LabelFontSize()*winSubgridFontScale*scale,
 			style.TextColorARGB(),
+			false,
 		)
 	}
 }
@@ -645,10 +648,11 @@ func (o *winOverlay) drawTextCentered(
 	fontFamily string,
 	fontSize float64,
 	color uint32,
+	bold bool,
 ) {
 	if o == nil || o.window == nil {
 		return
 	}
 
-	o.window.DrawTextCentered(text, bounds, fontFamily, fontSize, color)
+	o.window.DrawTextCentered(text, bounds, fontFamily, fontSize, color, bold)
 }

--- a/internal/adapter/overlay/windows/subgrid_test.go
+++ b/internal/adapter/overlay/windows/subgrid_test.go
@@ -27,6 +27,8 @@ type recordingWindow struct {
 	// the glyph is a label like any other on this surface, and a screen is
 	// the list of them.
 	texts []string
+	// bolds is, per entry of texts, whether it was painted bold.
+	bolds []bool
 	// rects is every rectangle filled or stroked, in order.
 	rects []image.Rectangle
 	// scale is what Scale answers. Zero means 1, a 100% display.
@@ -90,13 +92,15 @@ func (w *recordingWindow) DrawTextCentered(
 	_ string,
 	_ float64,
 	_ uint32,
-	_ bool,
+	bold bool,
 ) {
 	w.texts = append(w.texts, text)
+	w.bolds = append(w.bolds, bold)
 }
 
 func (w *recordingWindow) DrawPointerGlyph(_ image.Point, _ int, char string, _ string, _ uint32) {
 	w.texts = append(w.texts, char)
+	w.bolds = append(w.bolds, false)
 }
 
 func (w *recordingWindow) Flush() error { return nil }
@@ -105,6 +109,7 @@ func (w *recordingWindow) Flush() error { return nil }
 // the call under test painted.
 func (w *recordingWindow) forget() {
 	w.texts = nil
+	w.bolds = nil
 	w.rects = nil
 }
 

--- a/internal/adapter/overlay/windows/subgrid_test.go
+++ b/internal/adapter/overlay/windows/subgrid_test.go
@@ -90,6 +90,7 @@ func (w *recordingWindow) DrawTextCentered(
 	_ string,
 	_ float64,
 	_ uint32,
+	_ bool,
 ) {
 	w.texts = append(w.texts, text)
 }

--- a/internal/adapter/platform/linux/overlay_wayland.c
+++ b/internal/adapter/platform/linux/overlay_wayland.c
@@ -1119,7 +1119,7 @@ static const char *neru_resolve_font_family(const char *family) {
 
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color) {
+    unsigned int color, int bold) {
 	const char *resolved_family = neru_resolve_font_family(font_family);
 
 	for (int i = 0; i < overlay->nr_screens; i++) {
@@ -1134,7 +1134,8 @@ void neru_wayland_overlay_text(
 		cairo_t *cr = scr->cr;
 		cairo_text_extents_t extents;
 		cairo_save(cr);
-		cairo_select_font_face(cr, resolved_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+		cairo_select_font_face(
+		    cr, resolved_family, CAIRO_FONT_SLANT_NORMAL, bold ? CAIRO_FONT_WEIGHT_BOLD : CAIRO_FONT_WEIGHT_NORMAL);
 		cairo_set_font_size(cr, font_size);
 		cairo_text_extents(cr, text, &extents);
 		neru_wayland_overlay_color(cr, color);

--- a/internal/adapter/platform/linux/overlay_wayland.h
+++ b/internal/adapter/platform/linux/overlay_wayland.h
@@ -109,7 +109,7 @@ void neru_wayland_overlay_hint_badge(
     double stroke_width);
 void neru_wayland_overlay_text(
     NeruWaylandOverlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color);
+    unsigned int color, int bold);
 int neru_wayland_overlay_poll(NeruWaylandOverlay *overlay);
 const char *neru_wayland_overlay_get_key(NeruWaylandOverlay *overlay);
 

--- a/internal/adapter/platform/linux/x11_overlay.c
+++ b/internal/adapter/platform/linux/x11_overlay.c
@@ -285,11 +285,12 @@ void neru_x11_overlay_hint_badge(
 
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color) {
+    unsigned int color, int bold) {
 	cairo_t *cr = overlay->cr;
 	cairo_text_extents_t extents;
 	cairo_save(cr);
-	cairo_select_font_face(cr, font_family, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+	cairo_select_font_face(
+	    cr, font_family, CAIRO_FONT_SLANT_NORMAL, bold ? CAIRO_FONT_WEIGHT_BOLD : CAIRO_FONT_WEIGHT_NORMAL);
 	cairo_set_font_size(cr, font_size);
 	cairo_text_extents(cr, text, &extents);
 	neru_x11_overlay_color(cr, color);

--- a/internal/adapter/platform/linux/x11_overlay.h
+++ b/internal/adapter/platform/linux/x11_overlay.h
@@ -36,7 +36,7 @@ void neru_x11_overlay_hint_badge(
     double a_right, double tip_x, double tip_y, unsigned int fill, unsigned int stroke, double stroke_width);
 void neru_x11_overlay_text(
     NeruX11Overlay *overlay, const char *text, const char *font_family, double x, double y, double font_size,
-    unsigned int color);
+    unsigned int color, int bold);
 void neru_x11_overlay_flush(NeruX11Overlay *overlay);
 // neru_x11_overlay_scale returns the desktop-wide HiDPI UI scale from Xft.dpi
 // (clamped to [1.0, 4.0]); 1.0 when unset. See the implementation for why this

--- a/internal/adapter/platform/windows/ocr_integration_test.go
+++ b/internal/adapter/platform/windows/ocr_integration_test.go
@@ -61,7 +61,7 @@ func TestRecognizeText_ReadsAWordOffTheScreen(t *testing.T) {
 	textBox := card.Inset(40)
 
 	overlay := paintedOverlay(t, card, 0xFFFFFFFF)
-	overlay.DrawTextCentered(word, textBox, "", 48, 0xFF000000)
+	overlay.DrawTextCentered(word, textBox, "", 48, 0xFF000000, true)
 
 	flushErr := overlay.Flush()
 	if flushErr != nil {

--- a/internal/adapter/platform/windows/overlay.go
+++ b/internal/adapter/platform/windows/overlay.go
@@ -37,6 +37,7 @@ const (
 
 	defaultOverlayFont = "Segoe UI"
 	fwBold             = 700
+	fwNormal           = 400
 	dtCenter           = 0x00000001
 	dtVCenter          = 0x00000004
 	dtSingleLine       = 0x00000020
@@ -161,6 +162,7 @@ type drawCmd struct {
 	text     string
 	font     string
 	fontSize float64
+	bold     bool
 }
 
 // bounds is the rectangle a command can touch, before clipping to the surface.
@@ -673,13 +675,15 @@ func (o *OverlayWindow) FillTriangle(vertexA, vertexB, vertexC image.Point, colo
 	})
 }
 
-// DrawTextCentered renders centered text inside bounds.
+// DrawTextCentered renders centered text inside bounds. Hint labels, indicator
+// badges and the monitor-select label pass bold, matching the macOS adapter.
 func (o *OverlayWindow) DrawTextCentered(
 	text string,
 	bounds image.Rectangle,
 	fontFamily string,
 	fontSize float64,
 	color uint32,
+	bold bool,
 ) {
 	if o == nil || text == "" || bounds.Empty() {
 		return
@@ -696,6 +700,7 @@ func (o *OverlayWindow) DrawTextCentered(
 		text:     text,
 		font:     fontFamily,
 		fontSize: fontSize,
+		bold:     bold,
 	})
 }
 
@@ -729,6 +734,7 @@ func (o *OverlayWindow) DrawPointerGlyph(
 		fontFamily,
 		float64(size),
 		color,
+		false,
 	)
 }
 

--- a/internal/adapter/platform/windows/overlay_dcomp_amd64.go
+++ b/internal/adapter/platform/windows/overlay_dcomp_amd64.go
@@ -63,6 +63,7 @@ const (
 	d2dDefaultDPI               = 96
 
 	dwriteFactoryTypeShared    = 0
+	dwriteFontWeightNormal     = 400
 	dwriteFontWeightBold       = 700
 	dwriteFontStretchNormal    = 5
 	dwriteTextAlignmentCenter  = 2
@@ -466,15 +467,20 @@ func (s *dcompShared) release() {
 
 // textFormat returns the DirectWrite format for a family and size, creating it
 // once. A format is device-independent, so every window shares it.
-func (s *dcompShared) textFormat(family string, fontSize float64) (comObject, error) {
+func (s *dcompShared) textFormat(family string, fontSize float64, bold bool) (comObject, error) {
 	pixelSize := int(fontSize)
 	if pixelSize == 0 {
 		pixelSize = defaultFontSize
 	}
 
-	key := fontKey{family: family, size: pixelSize}
+	key := fontKey{family: family, size: pixelSize, bold: bold}
 	if format, ok := s.formats[key]; ok {
 		return format, nil
+	}
+
+	weight := uintptr(dwriteFontWeightNormal)
+	if bold {
+		weight = dwriteFontWeightBold
 	}
 
 	familyPtr, err := windows.UTF16PtrFromString(family)
@@ -494,7 +500,7 @@ func (s *dcompShared) textFormat(family string, fontSize float64) (comObject, er
 		vtblDWriteFactoryCreateTextFormat,
 		ptrArg(unsafe.Pointer(familyPtr)),
 		0,
-		dwriteFontWeightBold,
+		weight,
 		0,
 		dwriteFontStretchNormal,
 		floatArg(float32(pixelSize)),
@@ -950,7 +956,7 @@ func (s *dcompSurface) paintTriangle(cmd drawCmd) {
 }
 
 func (s *dcompSurface) paintText(cmd drawCmd) {
-	format, err := s.shared.textFormat(cmd.font, cmd.fontSize)
+	format, err := s.shared.textFormat(cmd.font, cmd.fontSize, cmd.bold)
 	if err != nil {
 		return
 	}

--- a/internal/adapter/platform/windows/overlay_gdi.go
+++ b/internal/adapter/platform/windows/overlay_gdi.go
@@ -307,6 +307,7 @@ type gdiTextRenderer struct {
 type fontKey struct {
 	family string
 	size   int
+	bold   bool
 }
 
 var gdiTextCache *gdiTextRenderer
@@ -352,15 +353,20 @@ func (r *gdiTextRenderer) ensureScratch(width, height int) error {
 }
 
 // font returns the realized HFONT for a family and size, creating it once.
-func (r *gdiTextRenderer) font(family string, fontSize float64) (uintptr, error) {
+func (r *gdiTextRenderer) font(family string, fontSize float64, bold bool) (uintptr, error) {
 	pixelSize := int(fontSize)
 	if pixelSize == 0 {
 		pixelSize = defaultFontSize
 	}
 
-	key := fontKey{family: family, size: pixelSize}
+	key := fontKey{family: family, size: pixelSize, bold: bold}
 	if hFont, ok := r.fonts[key]; ok {
 		return hFont, nil
+	}
+
+	weight := uintptr(fwNormal)
+	if bold {
+		weight = fwBold
 	}
 
 	fontName, err := windows.UTF16PtrFromString(family)
@@ -371,7 +377,7 @@ func (r *gdiTextRenderer) font(family string, fontSize float64) (uintptr, error)
 	// A negative height is the character height, which is what the
 	// configured size means; a positive one would include internal leading.
 	hFont, _, _ := procCreateFontW.Call(
-		uintptr(-pixelSize), 0, 0, 0, fwBold, 0, 0, 0, 1, 0, 0, 0, 0,
+		uintptr(-pixelSize), 0, 0, 0, weight, 0, 0, 0, 1, 0, 0, 0, 0,
 		uintptr(unsafe.Pointer(fontName)),
 	)
 	if hFont == 0 {
@@ -421,7 +427,7 @@ func (r *gdiTextRenderer) paint(pixels []byte, bufW, bufH int, cmd drawCmd) {
 		return
 	}
 
-	hFont, err := r.font(cmd.font, cmd.fontSize)
+	hFont, err := r.font(cmd.font, cmd.fontSize, cmd.bold)
 	if err != nil {
 		return
 	}

--- a/internal/adapter/platform/windows/overlay_integration_test.go
+++ b/internal/adapter/platform/windows/overlay_integration_test.go
@@ -51,7 +51,7 @@ func TestOverlayWindowLifecycleIntegration(t *testing.T) {
 
 	overlay.Clear()
 	overlay.FillRect(bounds, 0x8000FF00)
-	overlay.DrawTextCentered("FF", bounds, "Segoe UI", 48, 0xFFFFFFFF)
+	overlay.DrawTextCentered("FF", bounds, "Segoe UI", 48, 0xFFFFFFFF, true)
 	_ = overlay.Flush()
 	overlay.Show()
 	overlay.Hide()

--- a/internal/adapter/platform/windows/overlay_shapes_test.go
+++ b/internal/adapter/platform/windows/overlay_shapes_test.go
@@ -64,7 +64,7 @@ func TestClear_DrainsEveryCommandQueue(t *testing.T) {
 	window.FillRoundedRect(image.Rect(1, 1, 9, 9), 2, 0xFF0000FF)
 	window.FillTriangle(image.Pt(1, 1), image.Pt(5, 9), image.Pt(9, 1), 0xFF0000FF)
 	window.StrokeRect(image.Rect(1, 1, 9, 9), 0xFF0000FF, 1)
-	window.DrawTextCentered("a", image.Rect(1, 1, 9, 9), "Segoe UI", 10, 0xFF0000FF)
+	window.DrawTextCentered("a", image.Rect(1, 1, 9, 9), "Segoe UI", 10, 0xFF0000FF, true)
 
 	window.Clear()
 


### PR DESCRIPTION
## Description

This PR fixes the font weight of overlay text on Windows and Linux. Every string the overlay drew on those platforms was bold, regardless of surface, so grid labels, sub-key previews, the hint search input and the virtual pointer glyph came out heavier than the same surfaces on macOS.

Text now uses the weight the macOS adapter uses per surface. Hint labels, the mode and sticky-modifier badges and the monitor-select label stay bold. Grid, subgrid, recursive-grid labels, sub-key previews, the search input, the monitor-select subtitle and the virtual pointer glyph draw at regular weight. Both Windows renderers and both Linux backends follow the same table. No config option changes.

## Related Issues

None. Reported by a Windows user on the nightly build.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no port contract changed; only package-private primitives gained a parameter
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the same recipes individually on this host: `fmt-check`, `lint`, `vet`, `test`, `check-cross`, plus `lint-cross` for the Linux cgo build in Docker
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable) — N/A, font weight is not a documented capability
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Screenshots / Recordings

Not captured. This host is macOS, where nothing changes. A before/after from a Windows or Linux nightly would be welcome.

## Additional Context

The per-surface weight table was read off the macOS adapter, which resolves fonts with an explicit bold flag per call site. The `test-linux` Docker run has one pre-existing failure unrelated to this change, a GNOME focused-app test that needs `dbus-launch` in the image.
