### PR TITLE
fix(grid): plan cell sizes in apparent units on scaled Windows and X11 displays

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1300,8 +1300,8 @@ Cursor behavior: `neru recursive_grid --cursor-selection-mode follow|hold` (see 
 | `grid_cols`       | int    | `3`           | Columns (≥ 1; total cells ≥ 2)                                   |
 | `grid_rows`       | int    | `3`           | Rows (≥ 1; total cells ≥ 2)                                      |
 | `keys`            | string | `"rtyfghvbn"` | Cell selection keys (must be `grid_cols × grid_rows` characters) |
-| `min_size_width`  | int    | `1`           | Minimum cell width in pixels                                     |
-| `min_size_height` | int    | `1`           | Minimum cell height in pixels                                    |
+| `min_size_width`  | int    | `1`           | Minimum cell width, in apparent pixels (scaled with the display on Windows and X11) |
+| `min_size_height` | int    | `1`           | Minimum cell height, in apparent pixels (scaled with the display on Windows and X11) |
 | `max_depth`       | int    | `10`          | Maximum recursion levels (1–20)                                  |
 | `layers`          | array  | `[]`          | Per-depth layout overrides (see below)                           |
 

--- a/docs/CROSS_PLATFORM.md
+++ b/docs/CROSS_PLATFORM.md
@@ -581,6 +581,12 @@ important thing to know before touching overlay code:
 | **Coordinate origin** | bottom-left (Y-flipped in the adapter)   | top-left                               | top-left                                         | top-left                           |
 | **Thread model**      | main-thread dispatch                     | `renderMu` mutex                       | `renderMu` mutex (also guards `wl_display`)      | dedicated UI thread (`LockOSThread`); draws queue and return, the thread presents |
 
+Grid cell sizes are planned in apparent units on every platform. macOS and
+Wayland report logical screen bounds already. X11 and Windows report physical
+pixels, so the planner multiplies its cell-size range by the same factor the
+overlay scales fonts with (`SystemPort.ScreenScale`), and
+`recursive_grid.min_size_width` / `min_size_height` are read the same way.
+
 ### Animation
 
 | Animation                    | macOS                                | Linux X11 / Wayland                | Windows                            |

--- a/internal/adapter/platform/darwin/system.go
+++ b/internal/adapter/platform/darwin/system.go
@@ -78,6 +78,12 @@ func (s *SystemAdapter) ScreenBounds(ctx context.Context) (image.Rectangle, erro
 	return ActiveScreenBounds(), nil
 }
 
+// ScreenScale is 1 on macOS. Screen bounds are in points, which is the
+// apparent unit already.
+func (s *SystemAdapter) ScreenScale(ctx context.Context, bounds image.Rectangle) (float64, error) {
+	return 1, nil
+}
+
 // ScreenBoundsByName returns the bounds of the screen with the given localized
 // display name (case-insensitive) on macOS.
 func (s *SystemAdapter) ScreenBoundsByName(

--- a/internal/adapter/platform/linux/system_common.go
+++ b/internal/adapter/platform/linux/system_common.go
@@ -275,6 +275,25 @@ func (s *SystemAdapter) ScreenBounds(ctx context.Context) (image.Rectangle, erro
 	)
 }
 
+// ScreenScale returns the factor between the pixels ScreenBounds reports and
+// the apparent size the user sees. X11 has one coordinate space in physical
+// pixels and one desktop-wide Xft.dpi factor. Wayland bounds are logical, so
+// the factor is 1.
+func (s *SystemAdapter) ScreenScale(ctx context.Context, bounds image.Rectangle) (float64, error) {
+	if s.backend == backendX11 {
+		return x11DisplayScale()
+	}
+
+	if s.waylandUsesWlrClientStack() || s.backend == backendWaylandGNOME {
+		return 1, nil
+	}
+
+	return 0, derrors.New(
+		derrors.CodeNotSupported,
+		"ScreenScale not yet implemented on linux backend "+s.backend,
+	)
+}
+
 // ScreenBoundsByName returns the bounds of the screen with the given name on Linux.
 // TODO(linux): implement using XRandR or Wayland output protocol.
 func (s *SystemAdapter) ScreenBoundsByName(

--- a/internal/adapter/platform/linux/system_stub_contract_test.go
+++ b/internal/adapter/platform/linux/system_stub_contract_test.go
@@ -64,6 +64,14 @@ func stubCalls() []stubCall {
 			},
 		},
 		{
+			name: "ScreenScale",
+			call: func(ctx context.Context, a *linux.SystemAdapter) error {
+				_, err := a.ScreenScale(ctx, image.Rect(0, 0, 1, 1))
+
+				return err
+			},
+		},
+		{
 			name: "ScreenNames",
 			call: func(ctx context.Context, a *linux.SystemAdapter) error {
 				_, err := a.ScreenNames(ctx)

--- a/internal/adapter/platform/linux/system_x11_cgo.go
+++ b/internal/adapter/platform/linux/system_x11_cgo.go
@@ -456,3 +456,14 @@ func xwaylandRefreshCursorPosition(ctx context.Context) error {
 
 	return wlrootsSetCursor(image.Pt(int(posX), int(posY)))
 }
+
+// x11DisplayScale is the desktop-wide Xft.dpi factor, 1 when unset.
+func x11DisplayScale() (float64, error) {
+	display, err := x11OpenDisplay()
+	if err != nil {
+		return 0, err
+	}
+	defer C.neru_x11_close_display(display)
+
+	return float64(C.neru_x11_display_scale(display)), nil
+}

--- a/internal/adapter/platform/linux/system_x11_nocgo.go
+++ b/internal/adapter/platform/linux/system_x11_nocgo.go
@@ -86,3 +86,10 @@ func xwaylandRefreshCursorPosition(_ context.Context) error {
 		"Xwayland cursor discovery requires CGO-enabled Linux builds",
 	)
 }
+
+func x11DisplayScale() (float64, error) {
+	return 0, derrors.New(
+		derrors.CodeNotSupported,
+		"X11 display scale requires CGO-enabled Linux builds",
+	)
+}

--- a/internal/adapter/platform/linux/x11_overlay.c
+++ b/internal/adapter/platform/linux/x11_overlay.c
@@ -1,8 +1,9 @@
 #include "x11_overlay.h"
 
+#include "x11_system.h"
+
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
-#include <X11/Xresource.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/shape.h>
@@ -304,41 +305,14 @@ void neru_x11_overlay_flush(NeruX11Overlay *overlay) {
 	XFlush(overlay->display);
 }
 
-// neru_x11_overlay_scale returns the global UI scale for HiDPI displays, derived
-// from the "Xft.dpi" X resource (dpi / 96), clamped to [1.0, 4.0]. X11 has a
-// single coordinate space and no authoritative per-monitor scale, so this is a
-// desktop-wide factor: hint/label positions are already in device pixels and
-// stay put; callers multiply font sizes and stroke widths by this value so the
-// overlay renders at a legible size on HiDPI screens. Returns 1.0 when Xft.dpi
-// is unset (the common non-HiDPI case), so default setups are unaffected.
+// neru_x11_overlay_scale is neru_x11_display_scale for the overlay's display.
+// Hint and label positions are already in device pixels and stay put. Callers
+// multiply font sizes and stroke widths by this value so the overlay renders
+// at a legible size on HiDPI screens.
 double neru_x11_overlay_scale(NeruX11Overlay *overlay) {
-	if (overlay == NULL || overlay->display == NULL) {
+	if (overlay == NULL) {
 		return 1.0;
 	}
 
-	double scale = 1.0;
-	char *resource_string = XResourceManagerString(overlay->display);
-	if (resource_string != NULL) {
-		XrmInitialize();
-		XrmDatabase db = XrmGetStringDatabase(resource_string);
-		if (db != NULL) {
-			char *type = NULL;
-			XrmValue value;
-			if (XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &value) && value.addr != NULL) {
-				double dpi = atof(value.addr);
-				if (dpi > 0.0) {
-					scale = dpi / 96.0;
-				}
-			}
-			XrmDestroyDatabase(db);
-		}
-	}
-
-	if (scale < 1.0) {
-		scale = 1.0;
-	}
-	if (scale > 4.0) {
-		scale = 4.0;
-	}
-	return scale;
+	return neru_x11_display_scale(overlay->display);
 }

--- a/internal/adapter/platform/linux/x11_system.c
+++ b/internal/adapter/platform/linux/x11_system.c
@@ -4,6 +4,7 @@
 
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <X11/Xresource.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/XTest.h>
 #include <X11/extensions/Xrandr.h>
@@ -17,6 +18,38 @@
 #include <unistd.h>
 
 Display *neru_x11_open_display(void) { return XOpenDisplay(NULL); }
+
+double neru_x11_display_scale(Display *display) {
+	if (display == NULL) {
+		return 1.0;
+	}
+
+	double scale = 1.0;
+	char *resource_string = XResourceManagerString(display);
+	if (resource_string != NULL) {
+		XrmInitialize();
+		XrmDatabase db = XrmGetStringDatabase(resource_string);
+		if (db != NULL) {
+			char *type = NULL;
+			XrmValue value;
+			if (XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &value) && value.addr != NULL) {
+				double dpi = atof(value.addr);
+				if (dpi > 0.0) {
+					scale = dpi / 96.0;
+				}
+			}
+			XrmDestroyDatabase(db);
+		}
+	}
+
+	if (scale < 1.0) {
+		scale = 1.0;
+	}
+	if (scale > 4.0) {
+		scale = 4.0;
+	}
+	return scale;
+}
 
 void neru_x11_close_display(Display *display) {
 	if (display != NULL) {

--- a/internal/adapter/platform/linux/x11_system.h
+++ b/internal/adapter/platform/linux/x11_system.h
@@ -44,6 +44,11 @@ typedef enum {
 } NeruX11WindowPIDResult;
 
 Display *neru_x11_open_display(void);
+// neru_x11_display_scale returns the desktop-wide HiDPI UI scale, Xft.dpi / 96
+// clamped to [1.0, 4.0], and 1.0 when Xft.dpi is unset. X11 has a single
+// coordinate space in physical pixels and no authoritative per-monitor scale,
+// so this one factor is what an apparent size is multiplied by everywhere.
+double neru_x11_display_scale(Display *display);
 void neru_x11_close_display(Display *display);
 int neru_x11_query_pointer(Display *display, int *x, int *y);
 int neru_x11_discover_pointer(Display *display, int timeout_ms, int *x, int *y);

--- a/internal/adapter/platform/windows/system.go
+++ b/internal/adapter/platform/windows/system.go
@@ -162,6 +162,18 @@ func (s *SystemAdapter) ScreenBounds(ctx context.Context) (image.Rectangle, erro
 	return activeScreenBounds()
 }
 
+// ScreenScale returns the DPI scale of the monitor bounds sits on. The
+// process is per-monitor DPI aware, so bounds are physical pixels and this is
+// what turns an apparent size into them.
+func (s *SystemAdapter) ScreenScale(ctx context.Context, bounds image.Rectangle) (float64, error) {
+	err := ctx.Err()
+	if err != nil {
+		return 0, err
+	}
+
+	return DPIScaleAt(rectCenter(bounds)), nil
+}
+
 // ScreenBoundsByName returns the bounds of the screen with the given name on Windows.
 func (s *SystemAdapter) ScreenBoundsByName(
 	ctx context.Context,

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -100,6 +100,15 @@ func (h *handlerState) activateGridModeWithAction(activation modecmd.Activation)
 	h.startIndicatorPolling(domain.ModeGrid)
 }
 
+// gridOptionsFor is the configured grid options with the display scale of
+// screenBounds, so every grid built for that screen plans in apparent units.
+func (h *handlerState) gridOptionsFor(screenBounds image.Rectangle) domainGrid.Options {
+	options := h.config.GridOptions()
+	options.DisplayScale = h.screenScale(screenBounds)
+
+	return options
+}
+
 // createGridInstance creates a new grid with proper bounds and characters.
 func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	var screenBounds image.Rectangle
@@ -117,13 +126,10 @@ func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	h.setScreenBounds(screenBounds)
 
 	// Normalize normalizedBounds to window-local coordinates using helper function
-	options := h.config.GridOptions()
-	options.DisplayScale = h.screenScale(screenBounds)
-
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(screenBounds)
 
 	gridInstance := domainGrid.NewGridWithOptions(
-		options,
+		h.gridOptionsFor(screenBounds),
 		normalizedBounds,
 		h.logger,
 	)
@@ -151,11 +157,9 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 			}
 		}
 
-		options := h.config.GridOptions()
-		options.DisplayScale = h.screenScale(screenBounds)
 		bounds := image.Rect(0, 0, screenBounds.Dx(), screenBounds.Dy())
 		gridInstance = domainGrid.NewGridWithOptions(
-			options,
+			h.gridOptionsFor(screenBounds),
 			bounds,
 			h.logger,
 		)

--- a/internal/app/modes/grid.go
+++ b/internal/app/modes/grid.go
@@ -117,10 +117,13 @@ func (h *handlerState) createGridInstance() *domainGrid.Grid {
 	h.setScreenBounds(screenBounds)
 
 	// Normalize normalizedBounds to window-local coordinates using helper function
+	options := h.config.GridOptions()
+	options.DisplayScale = h.screenScale(screenBounds)
+
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(screenBounds)
 
 	gridInstance := domainGrid.NewGridWithOptions(
-		h.config.GridOptions(),
+		options,
 		normalizedBounds,
 		h.logger,
 	)
@@ -148,9 +151,11 @@ func (h *handlerState) initializeGridManager(gridInstance *domainGrid.Grid) {
 			}
 		}
 
+		options := h.config.GridOptions()
+		options.DisplayScale = h.screenScale(screenBounds)
 		bounds := image.Rect(0, 0, screenBounds.Dx(), screenBounds.Dy())
 		gridInstance = domainGrid.NewGridWithOptions(
-			h.config.GridOptions(),
+			options,
 			bounds,
 			h.logger,
 		)

--- a/internal/app/modes/grid_scale_test.go
+++ b/internal/app/modes/grid_scale_test.go
@@ -56,3 +56,25 @@ func TestCreateGridInstance_PlansTheGridInApparentUnits(t *testing.T) {
 		t.Fatalf("4K at 150%% planned %d cells, its 2560x1440 twin %d", got, want)
 	}
 }
+
+// TestRefreshGridForMonitorMove_PlansTheTargetScreenInApparentUnits pins the
+// same wiring on the monitor-move path, which rebuilds the grid from the target
+// screen's bounds without going through createGridInstance. A grid moved from
+// a 100% monitor to a 150% one has to be planned for the 150% one.
+func TestRefreshGridForMonitorMove_PlansTheTargetScreenInApparentUnits(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+	cfg.ResolveGridLabels()
+
+	handler := newScaledGridHandler(cfg, image.Rect(0, 0, 1920, 1080), 1.5)
+	handler.initializeGridManager(handler.createGridInstance())
+
+	handler.refreshGridForMonitorMove(image.Rect(1920, 0, 5760, 2160))
+
+	moved := handler.grid.Manager.Grid()
+	logical := newScaledGridHandler(cfg, image.Rect(0, 0, 2560, 1440), 1).createGridInstance()
+
+	if got, want := len(moved.Cells()), len(logical.Cells()); got != want {
+		t.Fatalf("grid moved onto 4K at 150%% has %d cells, its 2560x1440 twin %d", got, want)
+	}
+}

--- a/internal/app/modes/grid_scale_test.go
+++ b/internal/app/modes/grid_scale_test.go
@@ -1,0 +1,58 @@
+package modes
+
+import (
+	"context"
+	"image"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/y3owk1n/neru/internal/app/components"
+	gridcomponent "github.com/y3owk1n/neru/internal/app/components/grid"
+	"github.com/y3owk1n/neru/internal/config"
+	domainGrid "github.com/y3owk1n/neru/internal/domain/grid"
+	portmocks "github.com/y3owk1n/neru/internal/ports/mocks"
+)
+
+// newScaledGridHandler is a handler on a screen of the given size whose system
+// reports the given display scale, the shape Windows and X11 have.
+func newScaledGridHandler(cfg *config.Config, screen image.Rectangle, scale float64) *Handler {
+	var gridInstance *domainGrid.Grid
+
+	gridContext := &gridcomponent.Context{}
+	gridContext.SetGridInstance(&gridInstance)
+
+	return newHandlerWithState(handlerState{
+		config: cfg,
+		logger: zap.NewNop(),
+		grid:   &components.GridComponent{Context: gridContext},
+		system: &portmocks.MockSystemPort{
+			ScreenBoundsFunc: func(_ context.Context) (image.Rectangle, error) {
+				return screen, nil
+			},
+			ScreenScaleFunc: func(_ context.Context, _ image.Rectangle) (float64, error) {
+				return scale, nil
+			},
+		},
+		overlayPort:  &portmocks.MockOverlayPort{},
+		screenBounds: screen,
+	})
+}
+
+// TestCreateGridInstance_PlansTheGridInApparentUnits pins the mode-to-domain
+// wiring for the display scale. A 4K monitor at 150% gets as many cells as a
+// 2560x1440 monitor at 100%, each cell covering the same apparent size.
+// Before this was wired, raising Windows display scaling made the cells
+// smaller and denser.
+func TestCreateGridInstance_PlansTheGridInApparentUnits(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Grid.Enabled = true
+	cfg.ResolveGridLabels()
+
+	scaled := newScaledGridHandler(cfg, image.Rect(0, 0, 3840, 2160), 1.5).createGridInstance()
+	logical := newScaledGridHandler(cfg, image.Rect(0, 0, 2560, 1440), 1).createGridInstance()
+
+	if got, want := len(scaled.Cells()), len(logical.Cells()); got != want {
+		t.Fatalf("4K at 150%% planned %d cells, its 2560x1440 twin %d", got, want)
+	}
+}

--- a/internal/app/modes/handler.go
+++ b/internal/app/modes/handler.go
@@ -511,6 +511,26 @@ func (h *handlerState) setScreenBounds(bounds image.Rectangle) {
 	}
 }
 
+// screenScale is the display scale of bounds, 1 wherever the platform cannot
+// say. Sizes a user perceives, grid cells among them, are multiplied by it
+// before being laid out in the pixels bounds is measured in.
+func (h *handlerState) screenScale(bounds image.Rectangle) float64 {
+	if h.system == nil || bounds.Empty() {
+		return 1
+	}
+
+	scale, err := h.system.ScreenScale(h.ctx, bounds)
+	if err != nil {
+		if !derrors.IsNotSupported(err) {
+			h.logger.Warn("Failed to get screen scale", zap.Error(err))
+		}
+
+		return 1
+	}
+
+	return scale
+}
+
 // stopHeldRepeat cancels any running held-key repeat goroutine.
 func (h *handlerState) stopHeldRepeat() {
 	if h.heldRepeatingCancel != nil {

--- a/internal/app/modes/handler_refresh.go
+++ b/internal/app/modes/handler_refresh.go
@@ -202,6 +202,7 @@ func (h *handlerState) refreshRecursiveGridForScreenChange() {
 		// Proportionally remap all bounds (history + currentBounds) so the
 		// user's zoomed-in region maps to the equivalent area on the new screen.
 		h.recursiveGrid.Manager.CurrentGrid().RemapToNewBounds(normalizedBounds)
+		h.recursiveGrid.Manager.CurrentGrid().SetMinSize(h.recursiveGridMinSize())
 	} else {
 		// No existing manager — fall back to full initialization.
 		h.initializeRecursiveGridManager(normalizedBounds)

--- a/internal/app/modes/monitor.go
+++ b/internal/app/modes/monitor.go
@@ -321,7 +321,7 @@ func (h *handlerState) refreshGridForMonitorMove(targetBounds image.Rectangle) {
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(targetBounds)
 
 	gridInstance := domainGrid.NewGridWithOptions(
-		h.config.GridOptions(), normalizedBounds, h.logger,
+		h.gridOptionsFor(targetBounds), normalizedBounds, h.logger,
 	)
 	h.grid.Context.SetGridInstanceValue(gridInstance)
 
@@ -350,6 +350,7 @@ func (h *handlerState) refreshRecursiveGridForMonitorMove(targetBounds image.Rec
 	normalizedBounds := geometry.NormalizeToLocalCoordinates(targetBounds)
 	if h.recursiveGrid != nil && h.recursiveGrid.Manager != nil {
 		h.recursiveGrid.Manager.CurrentGrid().RemapToNewBounds(normalizedBounds)
+		h.recursiveGrid.Manager.CurrentGrid().SetMinSize(h.recursiveGridMinSize())
 	} else {
 		h.initializeRecursiveGridManager(normalizedBounds)
 	}

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -2,6 +2,7 @@ package modes
 
 import (
 	"image"
+	"math"
 
 	"go.uber.org/zap"
 
@@ -170,11 +171,15 @@ func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectang
 		depthKeys[layer.Depth] = layer.Keys
 	}
 
+	// The minimum cell sizes are apparent sizes. The grid is laid out in the
+	// pixels the screen bounds are measured in.
+	scale := h.screenScale(h.screenBounds)
+
 	h.recursiveGrid.Manager = recursivegrid.NewManagerWithLayers(
 		screenBounds,
 		h.config.RecursiveGrid.Keys,
-		h.config.RecursiveGrid.MinSizeWidth,
-		h.config.RecursiveGrid.MinSizeHeight,
+		int(math.Round(float64(h.config.RecursiveGrid.MinSizeWidth)*scale)),
+		int(math.Round(float64(h.config.RecursiveGrid.MinSizeHeight)*scale)),
 		h.config.RecursiveGrid.MaxDepth,
 		domain.GridDimensions{
 			Rows: h.config.RecursiveGrid.GridRows,

--- a/internal/app/modes/recursive_grid.go
+++ b/internal/app/modes/recursive_grid.go
@@ -151,6 +151,15 @@ func (h *handlerState) activateRecursiveGridModeWithAction(activation modecmd.Ac
 	h.startIndicatorPolling(domain.ModeRecursiveGrid)
 }
 
+// recursiveGridMinSize is the configured minimum cell size in the pixels the
+// active screen is measured in. The configured values are apparent sizes.
+func (h *handlerState) recursiveGridMinSize() (int, int) {
+	scale := h.screenScale(h.screenBounds)
+
+	return int(math.Round(float64(h.config.RecursiveGrid.MinSizeWidth) * scale)),
+		int(math.Round(float64(h.config.RecursiveGrid.MinSizeHeight) * scale))
+}
+
 // initializeRecursiveGridManager initializes the recursive-grid manager.
 func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectangle) {
 	if h.recursiveGrid == nil {
@@ -171,15 +180,13 @@ func (h *handlerState) initializeRecursiveGridManager(screenBounds image.Rectang
 		depthKeys[layer.Depth] = layer.Keys
 	}
 
-	// The minimum cell sizes are apparent sizes. The grid is laid out in the
-	// pixels the screen bounds are measured in.
-	scale := h.screenScale(h.screenBounds)
+	minWidth, minHeight := h.recursiveGridMinSize()
 
 	h.recursiveGrid.Manager = recursivegrid.NewManagerWithLayers(
 		screenBounds,
 		h.config.RecursiveGrid.Keys,
-		int(math.Round(float64(h.config.RecursiveGrid.MinSizeWidth)*scale)),
-		int(math.Round(float64(h.config.RecursiveGrid.MinSizeHeight)*scale)),
+		minWidth,
+		minHeight,
 		h.config.RecursiveGrid.MaxDepth,
 		domain.GridDimensions{
 			Rows: h.config.RecursiveGrid.GridRows,

--- a/internal/domain/grid/cache.go
+++ b/internal/domain/grid/cache.go
@@ -20,6 +20,7 @@ type CacheKey struct {
 	rowLabels      string
 	colLabels      string
 	maxLabelLength int
+	displayScale   float64
 	width          int
 	height         int
 }
@@ -45,12 +46,15 @@ var (
 	gridCacheEnabled = true
 )
 
-func newCacheKey(alpha gridAlphabet, maxLabelLength int, bounds image.Rectangle) CacheKey {
+func newCacheKey(
+	alpha gridAlphabet, maxLabelLength int, displayScale float64, bounds image.Rectangle,
+) CacheKey {
 	return CacheKey{
 		characters:     alpha.characters,
 		rowLabels:      string(alpha.rowChars),
 		colLabels:      string(alpha.colChars),
 		maxLabelLength: maxLabelLength,
+		displayScale:   displayScale,
 		width:          bounds.Dx(),
 		height:         bounds.Dy(),
 	}

--- a/internal/domain/grid/grid.go
+++ b/internal/domain/grid/grid.go
@@ -174,6 +174,11 @@ type Options struct {
 	RowLabels      string
 	ColLabels      string
 	MaxLabelLength int
+	// DisplayScale is how many physical pixels of bounds make one apparent
+	// unit: 1.5 on a Windows monitor at 150%, 1 wherever the bounds are
+	// already logical. The cell-size tiers describe apparent size, so the
+	// planner reads area and picks cell sizes in those units. Zero means 1.
+	DisplayScale float64
 }
 
 // NewGridWithOptions creates a grid from label options. MaxLabelLength limits
@@ -186,17 +191,19 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 	}
 
 	maxLabelLength := normalizeMaxLabelLength(options.MaxLabelLength)
+	scale := normalizeDisplayScale(options.DisplayScale)
 
 	logger.Debug("Creating new grid",
 		zap.String("characters", options.Characters),
 		zap.String("rowLabels", options.RowLabels),
 		zap.String("colLabels", options.ColLabels),
 		zap.Int("max_label_length", maxLabelLength),
+		zap.Float64("display_scale", scale),
 		zap.Int("bounds_width", bounds.Dx()),
 		zap.Int("bounds_height", bounds.Dy()))
 
 	alpha := newGridAlphabet(options.Characters, options.RowLabels, options.ColLabels)
-	cacheKey := newCacheKey(alpha, maxLabelLength, bounds)
+	cacheKey := newCacheKey(alpha, maxLabelLength, scale, bounds)
 
 	width := bounds.Max.X - bounds.Min.X
 	height := bounds.Max.Y - bounds.Min.Y
@@ -238,6 +245,7 @@ func NewGridWithOptions(options Options, bounds image.Rectangle, logger *zap.Log
 	plan := planGridDimensions(
 		width,
 		height,
+		scale,
 		alpha,
 		maxLabelLength,
 	)
@@ -403,6 +411,7 @@ type gridPlan struct {
 // longer labels retain their existing region layouts.
 func planGridDimensions(
 	width, height int,
+	scale float64,
 	alpha gridAlphabet,
 	maxLabelLength int,
 ) gridPlan {
@@ -410,7 +419,7 @@ func planGridDimensions(
 	numRowChars := len(alpha.rowChars)
 	numColChars := len(alpha.colChars)
 
-	minCellSize, maxCellSize := calculateOptimalCellSizes(width, height)
+	minCellSize, maxCellSize := calculateOptimalCellSizes(width, height, scale)
 	candidates := findValidGridConfigurations(width, height, minCellSize, maxCellSize)
 	gridCols, gridRows := selectBestCandidate(candidates, width, height, minCellSize, maxCellSize)
 
@@ -501,6 +510,16 @@ func normalizeMaxLabelLength(maxLabelLength int) int {
 	}
 
 	return gridMin(gridMax(maxLabelLength, MinLabelLength), DefaultMaxLabelLength)
+}
+
+// normalizeDisplayScale settles an unset or nonsensical scale to 1. Below 1
+// would mean a screen smaller than its own pixels.
+func normalizeDisplayScale(scale float64) float64 {
+	if scale < 1 {
+		return 1
+	}
+
+	return scale
 }
 
 // Characters returns the characters used for coordinates.

--- a/internal/domain/grid/sizing.go
+++ b/internal/domain/grid/sizing.go
@@ -135,7 +135,11 @@ func calculateOptimalCellSizes(width, height int, scale float64) (int, int) {
 		maxCellSize = int(float64(maxCellSize) * AspectRatioAdjustment)
 	}
 
-	return int(float64(minCellSize) * scale), int(float64(maxCellSize) * scale)
+	return int(
+			math.Round(float64(minCellSize) * scale),
+		), int(
+			math.Round(float64(maxCellSize) * scale),
+		)
 }
 
 // selectBestCandidate picks the candidate with the best (lowest) score.

--- a/internal/domain/grid/sizing.go
+++ b/internal/domain/grid/sizing.go
@@ -104,9 +104,12 @@ func betterTwoKeyCandidate(candidate, current twoKeyCandidate) bool {
 	}
 }
 
-// calculateOptimalCellSizes determines optimal cell size constraints based on screen characteristics.
-func calculateOptimalCellSizes(width, height int) (int, int) {
-	screenArea := width * height
+// calculateOptimalCellSizes determines the cell size range for a screen. The
+// tiers below are apparent sizes. A 4K monitor at 150% is a 2560x1440 desktop
+// to its user, so its area is read in those units and the range it picks is
+// scaled back up to the physical pixels the cells are laid out in.
+func calculateOptimalCellSizes(width, height int, scale float64) (int, int) {
+	screenArea := int(float64(width) / scale * float64(height) / scale)
 	screenAspect := float64(width) / float64(height)
 
 	var minCellSize, maxCellSize int
@@ -132,7 +135,7 @@ func calculateOptimalCellSizes(width, height int) (int, int) {
 		maxCellSize = int(float64(maxCellSize) * AspectRatioAdjustment)
 	}
 
-	return minCellSize, maxCellSize
+	return int(float64(minCellSize) * scale), int(float64(maxCellSize) * scale)
 }
 
 // selectBestCandidate picks the candidate with the best (lowest) score.

--- a/internal/domain/grid/sizing_internal_test.go
+++ b/internal/domain/grid/sizing_internal_test.go
@@ -13,7 +13,7 @@ func TestPlanGridDimensions_DefaultLimitKeepsLegacyTwoKeyRegions(t *testing.T) {
 	const characters = "abcdefghijklmnopqrstuvwxyz1234567890!@#$%^&*()-_=+"
 
 	alpha := newGridAlphabet(characters, "", "")
-	plan := planGridDimensions(1920, 1080, alpha, DefaultMaxLabelLength)
+	plan := planGridDimensions(1920, 1080, 1, alpha, DefaultMaxLabelLength)
 
 	if plan.labelLength != LabelLength2 {
 		t.Fatalf("label length = %d, want the automatic two-key fixture", plan.labelLength)
@@ -99,5 +99,63 @@ func TestPlanTwoKeyGrid_KeepsCellsNearSquareAcrossScreenShapes(t *testing.T) {
 				t.Errorf("plan uses %d prefix regions, only %d keys available", regions, keys)
 			}
 		})
+	}
+}
+
+// TestPlanGridDimensions_ScaledScreenPlansLikeItsLogicalTwin pins the
+// planner's units. The cell-size tiers describe apparent size, so a 4K monitor
+// at 150% has to get the grid a 2560x1440 monitor at 100% gets, not a third
+// more cells each a third smaller. Windows and X11 hand the planner physical
+// pixels, which is where the scale comes from.
+func TestPlanGridDimensions_ScaledScreenPlansLikeItsLogicalTwin(t *testing.T) {
+	alpha := newGridAlphabet(DefaultCharacters, "", "")
+
+	testCases := []struct {
+		name          string
+		width, height int
+		scale         float64
+		logicalW      int
+		logicalH      int
+	}{
+		{name: "4K at 150%", width: 3840, height: 2160, scale: 1.5, logicalW: 2560, logicalH: 1440},
+		{name: "4K at 200%", width: 3840, height: 2160, scale: 2, logicalW: 1920, logicalH: 1080},
+		{
+			name:     "1080p at 100%",
+			width:    1920,
+			height:   1080,
+			scale:    1,
+			logicalW: 1920,
+			logicalH: 1080,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scaled := planGridDimensions(
+				testCase.width, testCase.height, testCase.scale, alpha, DefaultMaxLabelLength,
+			)
+			logical := planGridDimensions(
+				testCase.logicalW, testCase.logicalH, 1, alpha, DefaultMaxLabelLength,
+			)
+
+			if scaled.dimensions != logical.dimensions {
+				t.Errorf("scaled screen planned %dx%d cells, its logical twin %dx%d",
+					scaled.dimensions.Cols, scaled.dimensions.Rows,
+					logical.dimensions.Cols, logical.dimensions.Rows)
+			}
+		})
+	}
+}
+
+// TestCalculateOptimalCellSizes_ScaleGrowsTheRangeWithThePixels pins the
+// other half. The range comes back in the pixels the cells are laid out in,
+// so a cell that is 50 apparent units wide is 75 physical pixels at 150%.
+func TestCalculateOptimalCellSizes_ScaleGrowsTheRangeWithThePixels(t *testing.T) {
+	minLogical, maxLogical := calculateOptimalCellSizes(2560, 1440, 1)
+	minScaled, maxScaled := calculateOptimalCellSizes(3840, 2160, 1.5)
+
+	if minScaled != minLogical*3/2 || maxScaled != maxLogical*3/2 {
+		t.Errorf("range at 150%% = %d..%d, want %d..%d (the logical %d..%d scaled up)",
+			minScaled, maxScaled, minLogical*3/2, maxLogical*3/2, minLogical, maxLogical)
 	}
 }

--- a/internal/domain/recursivegrid/recursive_grid.go
+++ b/internal/domain/recursivegrid/recursive_grid.go
@@ -339,6 +339,14 @@ func (qg *RecursiveGrid) MaxDepth() int {
 	return qg.maxDepth
 }
 
+// SetMinSize replaces the minimum cell size, in the pixels the bounds are
+// measured in. A grid remapped onto a screen with another display scale
+// keeps its apparent minimum by resetting this.
+func (qg *RecursiveGrid) SetMinSize(width, height int) {
+	qg.minSizeWidth = width
+	qg.minSizeHeight = height
+}
+
 // MinSizeWidth returns the minimum cell width.
 func (qg *RecursiveGrid) MinSizeWidth() int {
 	return qg.minSizeWidth

--- a/internal/ports/mocks/system.go
+++ b/internal/ports/mocks/system.go
@@ -18,6 +18,7 @@ type MockSystemPort struct {
 	ScreenBoundsFunc                   func(ctx context.Context) (image.Rectangle, error)
 	ScreenBoundsByNameFunc             func(ctx context.Context, name string) (image.Rectangle, bool, error)
 	ScreenNamesFunc                    func(ctx context.Context) ([]string, error)
+	ScreenScaleFunc                    func(ctx context.Context, bounds image.Rectangle) (float64, error)
 	FocusedWindowBoundsFunc            func(ctx context.Context) (image.Rectangle, bool, error)
 	MoveCursorToPointFunc              func(ctx context.Context, point image.Point, bypassSmooth bool) error
 	WaitForCursorIdleFunc              func(ctx context.Context) error
@@ -108,6 +109,16 @@ func (m *MockSystemPort) ScreenBoundsByName(
 	}
 
 	return image.Rectangle{}, false, nil
+}
+
+// ScreenScale is a mock implementation. Unset, it answers 1, a display whose
+// pixels are its apparent units.
+func (m *MockSystemPort) ScreenScale(ctx context.Context, bounds image.Rectangle) (float64, error) {
+	if m.ScreenScaleFunc != nil {
+		return m.ScreenScaleFunc(ctx, bounds)
+	}
+
+	return 1, nil
 }
 
 // ScreenNames is a mock implementation.

--- a/internal/ports/system.go
+++ b/internal/ports/system.go
@@ -57,6 +57,14 @@ type SystemPort interface {
 	// true if found, or a zero rectangle and false if no screen matches.
 	ScreenBoundsByName(ctx context.Context, name string) (image.Rectangle, bool, error)
 
+	// ScreenScale returns how many physical pixels of bounds, as ScreenBounds
+	// reports them, make one apparent unit on that screen: 1.5 on a Windows
+	// monitor at 150%, the Xft.dpi factor on X11, and 1 on macOS and Wayland,
+	// whose bounds are already logical. Callers size things a user perceives
+	// (grid cells) in apparent units and multiply by this. A platform that
+	// cannot read it returns CodeNotSupported, which callers treat as 1.
+	ScreenScale(ctx context.Context, bounds image.Rectangle) (float64, error)
+
 	// ScreenNames returns the localized display names of all connected screens.
 	// Returns nil or an empty slice when no screens are detected.
 	ScreenNames(ctx context.Context) ([]string, error)


### PR DESCRIPTION
## Description

This PR fixes grid mode planning too many, too-small cells on HiDPI displays on Windows and X11. The planner picked its cell-size range from the raw screen bounds, which on those platforms are physical pixels, so a 4K monitor at 150% display scaling was treated as a much larger screen than the 2560x1440 desktop its user sees. It got a third more cells, each a third smaller than intended, under labels that had already been scaled up. Raising display scaling made the grid denser.

The planner now works in apparent units. The system port reports each screen's display scale, the monitor DPI factor on Windows and Xft.dpi on X11, and the planner reads screen area in those units and scales its cell-size range back up to the pixels the cells are laid out in. A 4K monitor at 150% plans the same grid as a 2560x1440 monitor at 100%. macOS and Wayland already hand out logical bounds and report a scale of 1, so nothing changes there. The recursive grid's minimum cell sizes are read in apparent units the same way.

## Related Issues

None. Reported by a Windows user on the nightly build, following #1657.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — the X11 no-cgo stub and the unimplemented Linux backends refuse loudly, pinned by the Linux system stub contract test
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A, ran the same recipes individually on this host: `fmt-check`, `lint`, `vet`, `test`, `check-cross`, plus `lint-cross` and the touched Linux packages' tests with cgo in Docker
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users

## Config changes

No keys added or removed. `recursive_grid.min_size_width` and `recursive_grid.min_size_height` are now read as apparent pixels, so on a Windows or X11 display at 150% a value of 10 is 15 physical pixels. The defaults are 1 and unaffected in practice. Existing configs keep working.

## Screenshots / Recordings

Not captured. This host is macOS, where nothing changes. A before/after from a scaled Windows or X11 desktop would be welcome.

## Additional Context

The Xft.dpi reader the X11 overlay used moved into the X11 system C helpers so the system adapter and the overlay read the same factor. The `test-linux` Docker run has one pre-existing failure unrelated to this change, a GNOME focused-app test that needs `dbus-launch` in the image.
