### PR TITLE
fix(windows): use Direct2D for the overlay instead of silently falling back to GDI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -257,7 +257,10 @@ neru doctor
 Does not require a running daemon. Reports config validity, socket health,
 platform capabilities, and internal component state. Platform capabilities come
 from the capability matrix described in
-[CROSS_PLATFORM.md](CROSS_PLATFORM.md#capability-matrix).
+[CROSS_PLATFORM.md](CROSS_PLATFORM.md#capability-matrix). With the daemon
+running, the `Overlay backend` line names the renderer that is drawing right
+now rather than the matrix entry, which on Windows tells DirectComposition +
+Direct2D apart from the GDI fallback and says why the fallback was taken.
 
 The `platform_support` row answers a different question from those
 capabilities: it names the options, actions and mode flags **your**

--- a/internal/adapter/overlay/adapter.go
+++ b/internal/adapter/overlay/adapter.go
@@ -599,6 +599,25 @@ func (a *Adapter) SetKeyboardCaptureEnabled(enabled bool) {
 	controller.SetKeyboardCaptureEnabled(enabled)
 }
 
+// OverlayCapabilities reports the manager's live support state, so neru
+// doctor names the backend that is drawing rather than the platform preset.
+// A manager that cannot report is taken as supported with no detail, and a
+// destroyed overlay reports the same refusal Health does.
+func (a *Adapter) OverlayCapabilities() ports.FeatureCapability {
+	if a.released() {
+		return ports.FeatureCapability{
+			Status: ports.FeatureStatusStub,
+			Detail: "the overlay has been destroyed",
+		}
+	}
+
+	if reporter, ok := a.manager.(CapabilityReporter); ok {
+		return reporter.OverlayCapabilities()
+	}
+
+	return ports.FeatureCapability{Status: ports.FeatureStatusSupported}
+}
+
 // Health checks if the overlay manager is responsive.
 //
 // A destroyed overlay reports CodeNotSupported rather than answering healthy:

--- a/internal/adapter/overlay/windows/manager.go
+++ b/internal/adapter/overlay/windows/manager.go
@@ -260,9 +260,14 @@ func (m *Manager) WaylandKeyboardChannel() <-chan string {
 // OverlayCapabilities reports Windows overlay support.
 func (m *Manager) OverlayCapabilities() ports.FeatureCapability {
 	if m.win != nil && m.win.Healthy() {
-		detail := "native Windows overlays available via DirectComposition + Direct2D"
+		detail := "DirectComposition + Direct2D"
 		if m.win.backendName() == "gdi" {
-			detail = "native Windows overlays available via layered Win32 window + GDI"
+			detail = "layered Win32 window + GDI"
+
+			reason := m.win.dcompError()
+			if reason != nil {
+				detail += " (DirectComposition unavailable: " + reason.Error() + ")"
+			}
 		}
 
 		return ports.FeatureCapability{

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -38,6 +38,7 @@ type overlayWindow interface {
 	Visible() bool
 	Bounds() image.Rectangle
 	Backend() string
+	DCompError() error
 	Scale() float64
 	Show()
 	Hide()
@@ -447,6 +448,15 @@ func (o *winOverlay) backendName() string {
 	}
 
 	return o.window.Backend()
+}
+
+// dcompError is why the window is not on DirectComposition, or nil.
+func (o *winOverlay) dcompError() error {
+	if o == nil || o.window == nil {
+		return nil
+	}
+
+	return o.window.DCompError()
 }
 
 // redrawGrid paints the grid surface as it currently stands, which is either

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -133,6 +133,11 @@ func newWinOverlay(logger *zap.Logger, renderMu *sync.Mutex) *winOverlay {
 			zap.Int("height", bounds.Dy()),
 		)
 
+		reason := window.DCompError()
+		if reason != nil {
+			logger.Warn("Windows overlay fell back to GDI", zap.Error(reason))
+		}
+
 		// Per-frame cost, on the overlay UI thread after each present. Counts
 		// and durations only, which is what a report of "still laggy" needs.
 		window.SetFrameObserver(func(stats winplatform.FrameStats) {

--- a/internal/adapter/overlay/windows/overlay.go
+++ b/internal/adapter/overlay/windows/overlay.go
@@ -141,11 +141,25 @@ func newWinOverlay(logger *zap.Logger, renderMu *sync.Mutex) *winOverlay {
 
 		// Per-frame cost, on the overlay UI thread after each present. Counts
 		// and durations only, which is what a report of "still laggy" needs.
+		// A backend that changes mid-session is a lost device rebuilt on
+		// GDI, and that is warned once with the reason, since the startup
+		// warning above has already passed.
+		lastBackend := window.Backend()
+
 		window.SetFrameObserver(func(stats winplatform.FrameStats) {
 			if stats.Err != nil {
 				logger.Warn("overlay frame not presented", zap.Error(stats.Err))
 
 				return
+			}
+
+			if stats.Backend != lastBackend {
+				lastBackend = stats.Backend
+
+				fallback := window.DCompError()
+				if fallback != nil {
+					logger.Warn("Windows overlay fell back to GDI", zap.Error(fallback))
+				}
 			}
 
 			logger.Debug(

--- a/internal/adapter/overlay/windows/subgrid_test.go
+++ b/internal/adapter/overlay/windows/subgrid_test.go
@@ -43,7 +43,8 @@ func (w *recordingWindow) Visible() bool { return true }
 
 func (w *recordingWindow) Bounds() image.Rectangle { return image.Rect(0, 0, 800, 600) }
 
-func (w *recordingWindow) Backend() string { return "recording" }
+func (w *recordingWindow) Backend() string   { return "recording" }
+func (w *recordingWindow) DCompError() error { return nil }
 
 func (w *recordingWindow) Scale() float64 {
 	if w.scale <= 0 {

--- a/internal/adapter/platform/windows/overlay.go
+++ b/internal/adapter/platform/windows/overlay.go
@@ -844,7 +844,7 @@ func (o *OverlayWindow) renderPending() {
 	if err != nil {
 		// The surface is gone (a lost device, most likely). Come back on GDI
 		// and paint the frame there; the commands are just rectangles.
-		rebuildErr := o.rebuildOnGDI()
+		rebuildErr := o.rebuildOnGDI(err)
 		if rebuildErr != nil {
 			stats = FrameStats{Err: fmt.Errorf("%w; rebuilding on gdi: %w", err, rebuildErr)}
 		} else {
@@ -861,14 +861,16 @@ func (o *OverlayWindow) renderPending() {
 }
 
 // rebuildOnGDI tears the window down and recreates it on the GDI surface,
-// keeping it visible if it was. UI thread only.
-func (o *OverlayWindow) rebuildOnGDI() error {
+// keeping it visible if it was. reason is what took the surface down, kept
+// so DCompError can say why the window is on GDI. UI thread only.
+func (o *OverlayWindow) rebuildOnGDI(reason error) error {
 	o.mu.Lock()
 	visible := o.visible
 	o.mu.Unlock()
 
 	o.destroyHWNDLocked()
 	o.noDComp = true
+	o.dcompErr = reason
 
 	err := o.createHWNDLocked()
 	if err != nil {

--- a/internal/adapter/platform/windows/overlay.go
+++ b/internal/adapter/platform/windows/overlay.go
@@ -24,13 +24,16 @@ const (
 	wsExToolWindow          = 0x00000080
 	wsExNoActivate          = 0x08000000
 	wsExNoRedirectionBitmap = 0x00200000
-	swHide                  = 0
-	swShowNoActivate        = 4
-	hwndTopMost             = ^uintptr(0)
-	swpNoActivate           = 0x0010
-	swpShowWindow           = 0x0040
-	swpNoMove               = 0x0002
-	swpNoSize               = 0x0001
+	// lwaAlpha is LWA_ALPHA: SetLayeredWindowAttributes applies the alpha.
+	lwaAlpha         = 0x2
+	layeredOpaque    = 255
+	swHide           = 0
+	swShowNoActivate = 4
+	hwndTopMost      = ^uintptr(0)
+	swpNoActivate    = 0x0010
+	swpShowWindow    = 0x0040
+	swpNoMove        = 0x0002
+	swpNoSize        = 0x0001
 
 	wmNCHitTest   = 0x0084
 	htTransparent = ^uintptr(0) // HTTRANSPARENT, LRESULT -1
@@ -104,6 +107,7 @@ var (
 	procCreateWindowExW             = user32.NewProc("CreateWindowExW")
 	procDestroyWindow               = user32.NewProc("DestroyWindow")
 	procShowWindow                  = user32.NewProc("ShowWindow")
+	procSetLayeredWindowAttributes  = user32.NewProc("SetLayeredWindowAttributes")
 	procSetWindowPos                = user32.NewProc("SetWindowPos")
 	procDefWindowProcW              = user32.NewProc("DefWindowProcW")
 	procIsWindow                    = user32.NewProc("IsWindow")
@@ -909,7 +913,16 @@ func (o *OverlayWindow) createHWNDLocked() error {
 	if !o.noDComp {
 		err := dcompUnavailable()
 		if err == nil {
-			err = o.createWindowWithSurface(width, height, wsExNoRedirectionBitmap, newDCompSurface)
+			// Layered as well: WS_EX_TRANSPARENT only lets input through to
+			// other processes on a layered window, and a click lands while
+			// the overlay is still up. Without the redirection bitmap the
+			// layered style changes nothing about how the frame is drawn.
+			err = o.createWindowWithSurface(
+				width,
+				height,
+				wsExNoRedirectionBitmap|wsExLayered,
+				newDCompSurface,
+			)
 			if err == nil {
 				return nil
 			}
@@ -948,6 +961,14 @@ func (o *OverlayWindow) createWindowWithSurface(
 	)
 	if hwnd == 0 {
 		return fmt.Errorf("CreateWindowExW: %w", err)
+	}
+
+	// A layered window stays invisible until it has attributes. The GDI
+	// surface sets them with every UpdateLayeredWindow; the DirectComposition
+	// window never calls that, so it is made opaque once here and its own
+	// frames carry the alpha.
+	if exStyle&wsExNoRedirectionBitmap != 0 {
+		discardCall(procSetLayeredWindowAttributes.Call(hwnd, 0, layeredOpaque, lwaAlpha))
 	}
 
 	surface, err := newSurface(windows.HWND(hwnd), width, height)

--- a/internal/adapter/platform/windows/overlay.go
+++ b/internal/adapter/platform/windows/overlay.go
@@ -257,8 +257,10 @@ type OverlayWindow struct {
 	// surface is touched only on the overlay UI thread.
 	surface overlaySurface
 	// noDComp is set once DirectComposition failed for this window, so a
-	// rebuild does not try it again.
-	noDComp bool
+	// rebuild does not try it again. dcompErr says why, for the log line
+	// that reports the GDI fallback.
+	noDComp  bool
+	dcompErr error
 
 	observer func(FrameStats)
 }
@@ -399,6 +401,22 @@ func (o *OverlayWindow) Scale() float64 {
 // rectCenter is the point that looks up a rectangle's monitor.
 func rectCenter(rect image.Rectangle) image.Point {
 	return image.Pt(rect.Min.X+rect.Dx()/2, rect.Min.Y+rect.Dy()/2)
+}
+
+// DCompError reports why the window draws through GDI rather than
+// DirectComposition, or nil while DirectComposition is in use.
+func (o *OverlayWindow) DCompError() error {
+	if o == nil {
+		return nil
+	}
+
+	var err error
+
+	runOnOverlayUI(func() {
+		err = o.dcompErr
+	})
+
+	return err
 }
 
 // Backend names the surface this window presents through: "direct2d" when
@@ -886,13 +904,17 @@ func (o *OverlayWindow) createHWNDLocked() error {
 		return fmt.Errorf("%w: %v", errInvalidOverlayBounds, o.bounds)
 	}
 
-	if !o.noDComp && dcompAvailable() {
-		err := o.createWindowWithSurface(width, height, wsExNoRedirectionBitmap, newDCompSurface)
+	if !o.noDComp {
+		err := dcompUnavailable()
 		if err == nil {
-			return nil
+			err = o.createWindowWithSurface(width, height, wsExNoRedirectionBitmap, newDCompSurface)
+			if err == nil {
+				return nil
+			}
 		}
 
 		o.noDComp = true
+		o.dcompErr = err
 	}
 
 	return o.createWindowWithSurface(width, height, wsExLayered, newGDISurface)

--- a/internal/adapter/platform/windows/overlay_dcomp_amd64.go
+++ b/internal/adapter/platform/windows/overlay_dcomp_amd64.go
@@ -57,7 +57,7 @@ const (
 	d2dBitmapOptionsTarget      = 0x1
 	d2dBitmapOptionsCannotDraw  = 0x2
 	d2dTextAntialiasGrayscale   = 2
-	d2dCompositeModeSourceCopy  = 1
+	d2dCompositeModeSourceCopy  = 10
 	d2dFigureBeginFilled        = 0
 	d2dFigureEndClosed          = 1
 	d2dDefaultDPI               = 96

--- a/internal/adapter/platform/windows/overlay_dcomp_amd64.go
+++ b/internal/adapter/platform/windows/overlay_dcomp_amd64.go
@@ -124,6 +124,7 @@ const (
 
 var (
 	errDCompUnavailable = errors.New("directcomposition overlay unavailable")
+	errDCompDeviceLost  = errors.New("directcomposition device lost")
 
 	d3d11  = windows.NewLazySystemDLL("d3d11.dll")
 	dcomp  = windows.NewLazySystemDLL("dcomp.dll")
@@ -148,7 +149,7 @@ var (
 	//nolint:mnd // interface ID, as the SDK header spells it
 	iidIDXGISurface = windows.GUID{
 		Data1: 0xcafcb56c, Data2: 0x6ac3, Data3: 0x4889,
-		Data4: [8]byte{0xbf, 0x47, 0x9e, 0x23, 0xbb, 0xd2, 0x60, 0xc2},
+		Data4: [8]byte{0xbf, 0x47, 0x9e, 0x23, 0xbb, 0xd2, 0x60, 0xec},
 	}
 	//nolint:mnd // interface ID, as the SDK header spells it
 	iidIDCompositionDevice = windows.GUID{
@@ -290,15 +291,23 @@ var (
 	dcompBroken bool
 )
 
-// dcompAvailable reports whether DirectComposition can be used for new
-// windows. UI thread only. The first call brings the devices up; a failure
-// is remembered, and so is a device lost later.
-func dcompAvailable() bool {
+// dcompUnavailable is why DirectComposition cannot be used for new windows,
+// or nil when it can. UI thread only. The first call brings the devices up.
+// A failed init sticks, and so does a device lost later.
+func dcompUnavailable() error {
 	dcompOnce.Do(func() {
 		dcompState, errDComp = newDCompShared()
 	})
 
-	return errDComp == nil && !dcompBroken
+	if errDComp != nil {
+		return errDComp
+	}
+
+	if dcompBroken {
+		return errDCompDeviceLost
+	}
+
+	return nil
 }
 
 func newDCompShared() (*dcompShared, error) {
@@ -539,17 +548,14 @@ type dcompSurface struct {
 }
 
 func newDCompSurface(hwnd windows.HWND, width, height int) (overlaySurface, error) {
-	if !dcompAvailable() {
-		if errDComp != nil {
-			return nil, errDComp
-		}
-
-		return nil, errDCompUnavailable
+	err := dcompUnavailable()
+	if err != nil {
+		return nil, err
 	}
 
 	surface := &dcompSurface{shared: dcompState, hwnd: hwnd}
 
-	err := surface.create(width, height)
+	err = surface.create(width, height)
 	if err != nil {
 		surface.destroy()
 

--- a/internal/adapter/platform/windows/overlay_dcomp_other.go
+++ b/internal/adapter/platform/windows/overlay_dcomp_other.go
@@ -17,7 +17,7 @@ var errDCompUnavailable = errors.New(
 	"directcomposition overlay is only built for windows/amd64",
 )
 
-func dcompAvailable() bool { return false }
+func dcompUnavailable() error { return errDCompUnavailable }
 
 func newDCompSurface(windows.HWND, int, int) (overlaySurface, error) {
 	return nil, errDCompUnavailable

--- a/internal/app/ipcctrl/capabilities_test.go
+++ b/internal/app/ipcctrl/capabilities_test.go
@@ -267,3 +267,74 @@ func TestIPCController_StatusOmitsTheFocusedAppReasonWhenSupported(t *testing.T)
 			"to explain a capability that did not answer", got)
 	}
 }
+
+// reportingOverlay is an overlay port that can say what backend it is on,
+// the way every real overlay manager does through the adapter.
+type reportingOverlay struct {
+	*portmocks.MockOverlayPort
+
+	capability ports.FeatureCapability
+}
+
+func (o *reportingOverlay) OverlayCapabilities() ports.FeatureCapability {
+	return o.capability
+}
+
+func TestIPCController_StatusReportsLiveOverlayBackend(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := state.NewAppState()
+	logger := zap.NewNop()
+	configService := loader.NewService(cfg, "", logger, nil)
+	system := &portmocks.MockSystemPort{
+		CapabilitiesFunc: func() ports.PlatformCapabilities {
+			return ports.PlatformCapabilities{
+				Platform: testOS,
+				Overlay: ports.FeatureCapability{
+					Status: ports.FeatureStatusSupported,
+					Detail: "preset text that names what was built",
+				},
+			}
+		},
+	}
+	overlay := &reportingOverlay{
+		MockOverlayPort: &portmocks.MockOverlayPort{},
+		capability: ports.FeatureCapability{
+			Status: ports.FeatureStatusSupported,
+			Detail: "layered Win32 window + GDI",
+		},
+	}
+
+	controller := ipcctrl.New(ipcctrl.Deps{
+		ConfigService: configService,
+		AppState:      appState,
+		Config:        cfg,
+		System:        system,
+		Overlay:       overlay,
+		Logger:        logger,
+	})
+
+	resp := controller.HandleCommand(
+		context.Background(),
+		ipc.Command{Action: domain.CommandStatus},
+	)
+	if !resp.Success {
+		t.Fatalf("HandleCommand(status) success = false, want true")
+	}
+
+	statusData, statusDataOK := resp.Data.(map[string]any)
+	if !statusDataOK {
+		t.Fatalf("status data type = %T, want map[string]any", resp.Data)
+	}
+
+	capabilities, capabilitiesOK := statusData["capabilities"].(map[string]any)
+	if !capabilitiesOK {
+		t.Fatalf("capabilities type = %T, want map[string]any", statusData["capabilities"])
+	}
+
+	if capabilities["overlay_detail"] != "layered Win32 window + GDI" {
+		t.Fatalf(
+			"overlay_detail = %v, want the overlay's own report, not the preset",
+			capabilities["overlay_detail"],
+		)
+	}
+}

--- a/internal/app/ipcctrl/controller.go
+++ b/internal/app/ipcctrl/controller.go
@@ -29,6 +29,7 @@ type Controller struct {
 	// Infrastructure
 	Logger    *zap.Logger
 	System    ports.SystemPort
+	Overlay   ports.OverlayPort
 	EventTap  ports.EventTapPort
 	IPCServer ports.IPCPort
 	KeyFeed   ports.KeyFeedPort
@@ -83,7 +84,10 @@ type Deps struct {
 	Modes *modes.Handler
 
 	// Infrastructure ports
-	System    ports.SystemPort
+	System ports.SystemPort
+	// Overlay answers the live overlay capability for status and health. Nil
+	// leaves the system port's preset in place.
+	Overlay   ports.OverlayPort
 	EventTap  ports.EventTapPort
 	IPCServer ports.IPCPort
 	KeyFeed   ports.KeyFeedPort
@@ -116,6 +120,7 @@ func New(deps Deps) *Controller {
 		AppState:        deps.AppState,
 		Modes:           deps.Modes,
 		System:          deps.System,
+		Overlay:         deps.Overlay,
 		EventTap:        deps.EventTap,
 		IPCServer:       deps.IPCServer,
 		KeyFeed:         deps.KeyFeed,
@@ -214,6 +219,7 @@ func (c *Controller) registerHandlers(cfg *config.Config) {
 		ActionService: c.ActionService,
 		ScrollService: c.ScrollService,
 		System:        c.System,
+		Overlay:       c.Overlay,
 		EventTap:      c.EventTap,
 		IPCServer:     c.IPCServer,
 		ReloadConfig:  c.ReloadConfig,

--- a/internal/app/ipcctrl/info.go
+++ b/internal/app/ipcctrl/info.go
@@ -44,6 +44,7 @@ type InfoHandler struct {
 	actionService *services.ActionService
 	scrollService *services.ScrollService
 	systemPort    ports.SystemPort
+	overlay       ports.OverlayPort
 	eventTap      ports.EventTapPort
 	ipcServer     ports.IPCPort
 	reloadConfig  func(ctx context.Context, configPath string) error
@@ -77,6 +78,7 @@ type InfoHandlerDeps struct {
 	ScrollService *services.ScrollService
 
 	System    ports.SystemPort
+	Overlay   ports.OverlayPort
 	EventTap  ports.EventTapPort
 	IPCServer ports.IPCPort
 
@@ -103,6 +105,7 @@ func NewInfoHandler(deps InfoHandlerDeps) *InfoHandler {
 		actionService:  deps.ActionService,
 		scrollService:  deps.ScrollService,
 		systemPort:     deps.System,
+		overlay:        deps.Overlay,
 		eventTap:       deps.EventTap,
 		ipcServer:      deps.IPCServer,
 		reloadConfig:   deps.ReloadConfig,

--- a/internal/app/ipcctrl/info_health.go
+++ b/internal/app/ipcctrl/info_health.go
@@ -151,12 +151,22 @@ func (h *InfoHandler) handleHealth(ctx context.Context, _ ipc.Command) ipc.Respo
 	return response
 }
 
+// systemCapabilities is the platform preset with the overlay row replaced by
+// what the overlay reports about itself. The preset can only name what was
+// built; the manager knows what came up, which on Windows decides whether
+// hints draw through Direct2D or the GDI fallback.
 func (h *InfoHandler) systemCapabilities() ports.PlatformCapabilities {
-	if h.systemPort != nil {
-		return h.systemPort.Capabilities()
+	if h.systemPort == nil {
+		return ports.PlatformCapabilities{}
 	}
 
-	return ports.PlatformCapabilities{}
+	capabilities := h.systemPort.Capabilities()
+
+	if reporter, ok := h.overlay.(ports.OverlayCapabilityReporter); ok {
+		capabilities.Overlay = reporter.OverlayCapabilities()
+	}
+
+	return capabilities
 }
 
 func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
@@ -178,6 +188,12 @@ func capabilitiesMap(capabilities ports.PlatformCapabilities) map[string]any {
 	if detail := capabilities.DarkModeDetection.Detail; detail != "" &&
 		strings.HasPrefix(capabilities.Platform, "linux") {
 		out[string(ports.CapabilityDarkModeDetection)+detailSuffix] = detail
+	}
+
+	// The overlay detail is live wherever the overlay port reports it (see
+	// systemCapabilities), so it is surfaced whenever there is one.
+	if detail := capabilities.Overlay.Detail; detail != "" {
+		out[string(ports.CapabilityOverlay)+detailSuffix] = detail
 	}
 
 	// Notifications get the same treatment, gated on the status rather than on

--- a/internal/app/startup_phases.go
+++ b/internal/app/startup_phases.go
@@ -371,6 +371,7 @@ func initializeIPCController(app *App) {
 		Config:        app.config,
 		Modes:         app.modes,
 		System:        app.systemPort,
+		Overlay:       app.overlayPort,
 		// EventTap and IPCServer stay zero here; phase 8 fills them in
 		// through SetInfrastructure.
 		KeyFeed:         app.keyFeed,

--- a/internal/cli/cliutil/util.go
+++ b/internal/cli/cliutil/util.go
@@ -200,6 +200,7 @@ func (f *OutputFormatter) PrintHealth(cmd *cobra.Command, success bool, data any
 	}
 
 	printProfile(cmd, healthData["profile"])
+	printOverlayBackend(cmd, healthData["capabilities"])
 	printDarkMode(cmd, healthData["capabilities"])
 	printNotifications(cmd, healthData["capabilities"])
 	printFocusedApp(cmd, healthData["capabilities"])
@@ -314,6 +315,24 @@ func printDarkMode(cmd *cobra.Command, rawCapabilities any) {
 	}
 
 	cmd.Println("  Dark Mode: " + detail)
+}
+
+// printOverlayBackend renders an "Overlay backend:" line from overlay_detail,
+// which the daemon fills from the overlay itself. The profile's Overlay line
+// above it is the static plan; this one is what is drawing right now, which
+// on Windows is the difference between Direct2D and the GDI fallback.
+func printOverlayBackend(cmd *cobra.Command, rawCapabilities any) {
+	capabilities, ok := rawCapabilities.(map[string]any)
+	if !ok {
+		return
+	}
+
+	detail := stringValue(capabilities["overlay_detail"])
+	if detail == "" {
+		return
+	}
+
+	cmd.Println("  Overlay backend: " + detail)
 }
 
 // printNotifications renders a "Notifications:" metadata line when the daemon

--- a/internal/cli/cliutil/util_test.go
+++ b/internal/cli/cliutil/util_test.go
@@ -206,3 +206,36 @@ func TestPrintToggles_SkipsAbsentState(t *testing.T) {
 		t.Fatalf("printToggles output missing the toggles that do carry state:\n%s", got)
 	}
 }
+
+func TestPrintOverlayBackend(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	printOverlayBackend(cmd, map[string]any{
+		"overlay_detail": "layered Win32 window + GDI",
+	})
+
+	want := "  Overlay backend: layered Win32 window + GDI\n"
+	if got := output.String(); got != want {
+		t.Fatalf("printOverlayBackend output = %q, want %q", got, want)
+	}
+}
+
+func TestPrintOverlayBackend_SkipsAbsentDetail(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+
+	printOverlayBackend(cmd, map[string]any{"overlay_detail": ""})
+
+	if got := output.String(); got != "" {
+		t.Fatalf("printOverlayBackend output = %q, want nothing", got)
+	}
+}

--- a/internal/ports/capability_presets.go
+++ b/internal/ports/capability_presets.go
@@ -182,7 +182,9 @@ func WindowsCapabilities() PlatformCapabilities {
 			"clickable-element discovery available via UI Automation (initial coverage)",
 		),
 		Overlay: supportedCapability(
-			"native overlays available via DirectComposition + Direct2D (GDI fallback)",
+			"native overlays via DirectComposition + Direct2D, or a layered GDI " +
+				"window when that fails; neru doctor with the daemon running " +
+				"names the one drawing",
 		),
 		Notifications: supportedCapability(
 			"notifications shown as balloon tips on the tray icon (Shell_NotifyIcon " +


### PR DESCRIPTION
## Description

This PR fixes the Windows overlay so it draws through DirectComposition and Direct2D as designed, instead of always landing on the GDI fallback.

A wrong last byte in the IDXGISurface interface ID made every swapchain buffer lookup fail, so Direct2D setup failed on every window and the overlay drew with GDI fonts instead of DirectWrite. Nothing reported it: the fallback dropped the error and the startup log only named the backend.

With the corrected interface ID, DirectComposition comes up on windows/amd64. When it still cannot, the overlay now logs a warning with the reason right after the "window ready" line, so a report of "hints look different on Windows" carries the cause.

Running Direct2D for the first time exposed a second constant error: the canvas was copied into the swapchain back buffer with a composite mode of DESTINATION_OVER rather than SOURCE_COPY, so each frame was drawn beneath the previous one. Every recursive-grid depth and every mode stacked up on screen, and hiding the window only paused it. That copy now replaces the buffer.

Third, clicks went nowhere: a mode's action fires while its overlay is still up, and the DirectComposition window was transparent but not layered, which Windows only honours as click-through for layered windows. That window is now layered too, so a selection's click reaches the app beneath, as it did on GDI.

`neru doctor` had the same blind spot: its overlay row came from the platform preset, which named DirectComposition + Direct2D while GDI was drawing. With the daemon running, doctor now prints an `Overlay backend` line taken from the overlay itself. On Windows it names Direct2D or GDI and, for GDI, why DirectComposition was unavailable, including a device lost after startup. Without the daemon, the Windows preset no longer claims a backend.

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [ ] Linux
- [x] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, change stays inside the Windows adapter; the non-amd64 Windows build keeps its existing GDI-only path and now reports that as the reason
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows — partial: ran fmt-check, check-cross, vet, test-foundation, and golangci-lint on the two Windows packages for windows/amd64 and windows/arm64; the Windows overlay code needs a Windows session to run, so CI's Windows job is the real gate
- [x] Tests added/updated for new or changed functionality — the live overlay row and the doctor line are unit-tested; the Direct2D path itself only runs against a live Windows compositor
- [x] Documentation updated (if applicable) — `docs/CLI.md` describes the new doctor line
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

## Doctor output change

With the daemon running, `neru doctor` gains one line under the profile block:

```
  Overlay backend: layered Win32 window + GDI (DirectComposition unavailable: IDXGISwapChain::GetBuffer failed: 0x80004002)
```

The `overlay` capability row keeps its status; only the detail behind it is live now. The IPC `status` and `health` responses carry it as `overlay_detail`, on every platform whose overlay reports one.

## Additional Context

The correct interface ID is `{cafcb56c-6ac3-4889-bf47-9e23bbd260ec}`; the last byte read `c2`. `D2D1_COMPOSITE_MODE_SOURCE_COPY` is 10; the code used 1, which is `DESTINATION_OVER`. Every other enum value in that constant block was checked against the SDK headers. The fallback reason is remembered per window and read on the overlay UI thread, the same way the backend name already is. Only the main overlay logs it, so the badge and subgrid windows stay quiet.
