### PR TITLE
fix(linux): make a bare modifier tap reach the compositor while a mode is open

### DIFF
--- a/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
+++ b/docs/adr/0014-the-wayland-keyboard-is-a-proxy.md
@@ -61,8 +61,13 @@ what every other platform's hotkey mechanism already does. Modifier passthrough
 becomes "re-emit this press after all": the held modifiers go out with it and
 stay the compositor's until they are physically released, with no re-tap per
 auto-repeat and nothing to unwind when the mode ends. And a mode never sees the
-activation chord's modifier, since the session counts only presses withheld for
-it, so a hint label typed while Super is still coming up is the label.
+activation chord's modifier, since the session counts only presses made after
+it began, so a hint label typed while Super is still coming up is the label.
+Modifiers themselves are never withheld, in a mode or out of one. The
+compositor's picture of them is always the physical one, and a compositor bind
+on a bare modifier keeps firing while a mode is open (#1665). That is what the
+other platforms do already. The macOS tap returns every flags-changed event and
+the Windows hook forwards every modifier.
 
 Withholding has one side effect the tap never had, because the tap left the
 chord's key with the compositor. A modifier pressed and released with nothing

--- a/internal/adapter/eventtap/linux/evdev_forward.go
+++ b/internal/adapter/eventtap/linux/evdev_forward.go
@@ -15,8 +15,9 @@ const evdevBitsPerWord = 64
 //
 // The whole of it is one invariant, and the invariant is what makes an instant
 // grab safe: **a release is forwarded exactly when its press was.** A press is
-// forwarded whenever no mode is capturing, and withheld otherwise; its release
-// then follows the press wherever it went, and a repeat follows the press too.
+// forwarded whenever no mode is capturing, and withheld otherwise, except that
+// a modifier's press is always forwarded (handleKey). Its release then follows
+// the press wherever it went, and a repeat follows the press too.
 // So a mode that starts under a held activation chord costs nothing — the
 // chord's presses went to the compositor, so their releases do as well, and the
 // compositor's picture of the keyboard is never wrong in either direction. That

--- a/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_cgo.go
@@ -429,10 +429,11 @@ func (p *evdevProxy) handleKey(event waylandEvdevEvent) {
 		// A chord the idle matcher takes is withheld, so the focused app never
 		// sees the activation chord — what the macOS tap does by consuming
 		// the event. The match runs before the forward decision for that.
-		withhold := p.session != nil
-		if !withhold && modifier == "" && p.matchHotkey(code) {
-			withhold = true
-		}
+		//
+		// A modifier is never withheld, so a compositor bind on a bare
+		// modifier keeps firing while a mode is open (#1665), as on macOS
+		// and Windows. The session still reads it for its sticky toggle.
+		withhold := modifier == "" && (p.session != nil || p.matchHotkey(code))
 
 		forwarded := p.rule.press(code, withhold)
 		if forwarded {

--- a/internal/adapter/eventtap/linux/evdev_proxy_test.go
+++ b/internal/adapter/eventtap/linux/evdev_proxy_test.go
@@ -517,6 +517,40 @@ func TestEvdevProxy_SessionStartsUnderTheChordWithoutCountingIt(t *testing.T) {
 	}
 }
 
+// A modifier tapped while a mode is open reaches the compositor, press and
+// release, so a compositor bind on the bare modifier keeps firing. In #1665
+// Super alone toggled grid on Hyprland until the evdev capture engaged, then
+// every tap was swallowed as a sticky toggle. The mode still reads the tap as
+// one, as on macOS, where the tap returns every flags-changed event.
+func TestEvdevProxy_SessionForwardsAModifierTapToTheCompositor(t *testing.T) {
+	t.Parallel()
+
+	proxy := newTestProxy()
+	tap, keys := collectKeys(t)
+	tap.SetStickyModifierToggle(true)
+	beginSession(proxy, tap)
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValuePress))
+
+	if !proxy.rule.isDown(evdevKeyLeftMeta) {
+		t.Fatal("a modifier pressed during the session was withheld from the compositor")
+	}
+
+	if got := nextKey(t, keys); got != "__modifier_cmd_down" {
+		t.Fatalf("dispatched %q for a forwarded Super press, want a sticky toggle", got)
+	}
+
+	proxy.handle(keyEvent(evdevKeyLeftMeta, evdevValueRelease))
+
+	if proxy.rule.isDown(evdevKeyLeftMeta) {
+		t.Fatal("the modifier's release did not follow its press to the compositor")
+	}
+
+	if got := nextKey(t, keys); got != "__modifier_cmd_up" {
+		t.Fatalf("dispatched %q for a forwarded Super release, want a sticky toggle", got)
+	}
+}
+
 // A press withheld for the mode is followed by its release: the mode sees both,
 // the compositor neither. A release for a press the mode never saw reaches it
 // no more than the press did.
@@ -587,8 +621,8 @@ func TestEvdevProxy_PassthroughForwardsTheChordAndItsHeldModifiers(t *testing.T)
 
 	proxy.handle(keyEvent(evdevKeyLeftCtrl, evdevValuePress))
 
-	if proxy.rule.isDown(evdevKeyLeftCtrl) {
-		t.Fatal("a modifier pressed during the session was forwarded before anything used it")
+	if !proxy.rule.isDown(evdevKeyLeftCtrl) {
+		t.Fatal("a modifier pressed during the session was withheld from the compositor")
 	}
 
 	proxy.handle(keyEvent(evdevKeyC, evdevValuePress))

--- a/internal/adapter/eventtap/linux/evdev_session_cgo.go
+++ b/internal/adapter/eventtap/linux/evdev_session_cgo.go
@@ -16,13 +16,15 @@ import (
 // evdevSession is the consumer of key events while a mode is open. Every
 // method runs on the proxy's run goroutine.
 //
-// It keeps its own picture of the modifiers, counting only presses the proxy
-// withheld for it. A modifier that was already down when the session began —
-// the activation chord's — was forwarded, so the compositor owns its release
-// and the mode never sees it as a sticky toggle. It still names chords while
-// it is down. The macOS tap reads it off every event's flags and the X11 tap
-// counts it from the keyboard state after the grab, so Alt held from the
-// activation chord and Space pressed again is Alt+Space on every platform.
+// It keeps its own picture of the modifiers, counting only presses made since
+// it began. Every modifier press is forwarded to the compositor, and the
+// session reads it on the way past, as the macOS tap reads the flags off an
+// event it returns. A modifier already down when the session began is the
+// activation chord's. The mode never sees that one as a sticky toggle, though
+// it still names chords while it is down. The macOS tap reads it off every
+// event's flags and the X11 tap counts it from the keyboard state after the
+// grab, so Alt held from the activation chord and Space pressed again is
+// Alt+Space on every platform.
 // Sticky detection arms once the chord has finished coming up, and the
 // session's own count starts at a clean slate.
 type evdevSession struct {
@@ -71,16 +73,22 @@ func (s *evdevSession) begin(proxy *evdevProxy) {
 }
 
 func (s *evdevSession) handlePress(code uint16, modifier string, forwarded bool) {
-	if forwarded {
-		// Held before the session, or a second keyboard repeating a key the
-		// compositor already has down: not the mode's.
-		return
-	}
-
 	if modifier != "" {
+		// Forwarded, like every modifier. The session reads it unless it
+		// is the activation chord's, on this keyboard or a second one.
+		if s.forwardedModifiers[code] {
+			return
+		}
+
 		s.state.trackModifier(code, modifier, true)
 		s.dispatchStickyToggle(modifier, true)
 
+		return
+	}
+
+	if forwarded {
+		// A second keyboard repeating a key the compositor already has down:
+		// not the mode's.
 		return
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a compositor bind on a bare modifier key stopping once Neru's Wayland keyboard capture engaged. With `neru grid -t` bound to Super alone in Hyprland, the first toggles worked and then Super appeared to die: the tap was swallowed as a sticky-modifier toggle and the mode stayed open.

While a mode was capturing, the evdev proxy withheld every key from the compositor, modifiers included. Modifier presses and releases now always reach the compositor, in a mode or out of one, so the bind keeps firing and the compositor's picture of the modifiers stays the physical one. The mode still reads the tap for sticky modifiers, and a chord typed inside a mode still does not open the launcher on KWin or Mutter. This is what macOS and Windows already do.

## Related Issues

Closes #1665

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [x] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [x] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [x] Stub implementations added for other platforms (returning `CodeNotSupported`) — N/A, no new port; the change is inside the existing Linux evdev adapter
- [ ] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — N/A as one recipe on this aarch64 host, where `just build` cannot find the cairo and XInput headers; lint, vet, the full test set, a unit `-race` pass on the changed package, and the CGO-off Linux and Windows type-checks were run individually and pass
- [x] Tests added/updated for new or changed functionality
- [x] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/) subject written for users — this PR squash-merges, so the title is what Release Please ships in the changelog, not the commits on the branch

## Behaviour change to note

A bare Super tap inside a mode now reaches the compositor. On GNOME or KDE with Super bound to the launcher, tapping Super alone while a mode is open opens the launcher as well as toggling sticky Super. Before, the tap was swallowed. This cannot be split, since Hyprland's release bind and the GNOME launcher are the same "modifier pressed and released alone" check, and it is how a Win tap already behaves inside a mode on Windows. Chords typed inside a mode are unaffected.

## Additional Context

Reproduced on Hyprland with a virtual uinput keyboard and a `bindr` on `SUPER_L`: before the fix the log matched the issue exactly (three toggles under the overlay-focus fallback, then stuck in grid with "Sticky modifier toggled Super" once evdev capture engaged). After the fix six taps toggled grid in and out every time, and the proxy's kernel key state for Super was clear afterwards.
