### PR TITLE
build(devbox): make devbox shell work from fish

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -89,10 +89,8 @@
 			"platforms": ["x86_64-linux", "aarch64-linux"]
 		}
 	},
-	"shell": {
-		"init_hook": [
-			"if [[ \"$(uname)\" == \"Linux\" ]]; then export PKG_CONFIG_PATH=\"$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}\"; fi",
-			"if [[ \"$(uname)\" == \"Linux\" && -z \"${TESSDATA_PREFIX:-}\" ]]; then export TESSDATA_PREFIX=\"$(pkg-config --variable=prefix tesseract 2>/dev/null)/share/tessdata\"; fi"
-		]
+	"env": {
+		"PKG_CONFIG_PATH": "$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig:$PKG_CONFIG_PATH",
+		"TESSDATA_PREFIX": "$DEVBOX_PACKAGES_DIR/share/tessdata"
 	}
 }

--- a/devbox.json
+++ b/devbox.json
@@ -90,7 +90,11 @@
 		}
 	},
 	"env": {
-		"PKG_CONFIG_PATH": "$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig:$PKG_CONFIG_PATH",
-		"TESSDATA_PREFIX": "$DEVBOX_PACKAGES_DIR/share/tessdata"
+		"PKG_CONFIG_PATH": "$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig:$PKG_CONFIG_PATH"
+	},
+	"shell": {
+		"init_hook": [
+			"test -n \"$TESSDATA_PREFIX\" || export TESSDATA_PREFIX=\"$DEVBOX_PACKAGES_DIR/share/tessdata\""
+		]
 	}
 }

--- a/devbox.json
+++ b/devbox.json
@@ -94,7 +94,7 @@
 	},
 	"shell": {
 		"init_hook": [
-			"test -n \"$TESSDATA_PREFIX\" || export TESSDATA_PREFIX=\"$DEVBOX_PACKAGES_DIR/share/tessdata\""
+			"printenv TESSDATA_PREFIX | grep -q . || export TESSDATA_PREFIX=\"$DEVBOX_PACKAGES_DIR/share/tessdata\""
 		]
 	}
 }


### PR DESCRIPTION
## Description

This PR makes `devbox shell` work when the login shell is fish.

`devbox shell` sources `shell.init_hook` in the user's own shell. Both hooks were bash (`[[ ]]`, `then`/`fi`, `${VAR:+...}`), so fish stopped with `Missing end to balance this if statement` while sourcing `.devbox/gen/scripts/.hooks.sh`, and neither `PKG_CONFIG_PATH` nor `TESSDATA_PREFIX` was set. The direnv path was never affected because `.envrc` runs under bash.

`PKG_CONFIG_PATH` now lives in devbox's `env` block, which devbox expands itself without a shell. `TESSDATA_PREFIX` stays in `init_hook`, as one line that bash, sh and fish all parse, because it must keep a value the user already set and devbox's `env` expansion has no `${VAR:-default}` form. It asks `printenv` rather than expanding the variable, so it also works when bash or zsh runs with `set -u`:

```json
"env": {
	"PKG_CONFIG_PATH": "$DEVBOX_PACKAGES_DIR/lib/pkgconfig:$DEVBOX_PACKAGES_DIR/share/pkgconfig:$PKG_CONFIG_PATH"
},
"shell": {
	"init_hook": [
		"printenv TESSDATA_PREFIX | grep -q . || export TESSDATA_PREFIX=\"$DEVBOX_PACKAGES_DIR/share/tessdata\""
	]
}
```

## Related Issues

None.

## Target Platform

- [ ] Platform-agnostic (shared logic, no OS-specific code)
- [ ] macOS
- [x] Linux
- [ ] Windows

## Type of Change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation only
- [ ] `test` — Adding or updating tests
- [x] `chore` — Build, CI, dependencies, tooling

## Cross-Platform Checklist

- [ ] OS-specific files use correct build tags (e.g., `//go:build darwin`)
- [ ] No darwin imports from untagged (shared) code — [The One Rule](https://github.com/y3owk1n/neru/blob/main/docs/ARCHITECTURE.md#the-one-rule)
- [ ] Stub implementations added for other platforms (returning `CodeNotSupported`)
- [x] N/A — This PR does not touch platform-specific code

## General Checklist

- [x] Code formatted (`just fmt`)
- [x] `just ci` passes — the same checks CI runs, on your host only (format
      check, lint, vet, build, a CGO-off type-check of the Linux and Windows
      builds, tests including a unit `-race` pass, vulnerability scan); CI
      runs them on macOS, Linux and Windows
- [ ] Tests added/updated for new or changed functionality
- [ ] Documentation updated (if applicable)
- [x] PR title is a [conventional commit](https://www.conventionalcommits.org/)
      subject written for users — this PR squash-merges, so the title is what
      Release Please ships in the changelog, not the commits on the branch

No tests or docs. This only changes the dev shell config.

## Additional Context

How it was checked on Linux (aarch64, devbox 0.17.5), from a clean environment so direnv's variables did not leak in:

- `devbox run` sets `PKG_CONFIG_PATH` to the profile's `lib/pkgconfig` and `share/pkgconfig`, and `TESSDATA_PREFIX` to the profile's `share/tessdata`, which holds the `*.traineddata` files. `pkg-config` resolves cairo, x11, wayland-client and xkbcommon.
- With `TESSDATA_PREFIX=/custom` already exported, `devbox run` keeps `/custom`, matching the `--set-default` behaviour of the Nix wrappers and the `tessdata_fast` setup in `docs/LINUX_SETUP.md`.
- The regenerated `.hooks.sh` passes `fish -n`. Sourcing it in fish and in `bash -u` gives the profile path when the variable is unset or blank, and keeps `/custom` when it is set.
- `devbox shell` under bash with `set -u` in `.bashrc` comes up with `TESSDATA_PREFIX` set. The only unbound-variable error left is devbox's own `DEVBOX_NO_PROMPT`.

Trade-offs:

- Both variables are now set on macOS too, where the old hooks were Linux-only. That is harmless because the paths do not exist there and tesseract is Linux-only in `devbox.json`.
- The hook needs fish 3.0 or later for `||`.
